### PR TITLE
`pkgs.lib.getExe` is required to `nix run` a Cabal drv

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -99,7 +99,7 @@ in
               in
               rec {
                 package = mkProject { };
-                app = { type = "app"; program = package; };
+                app = { type = "app"; program = pkgs.lib.getExe package; };
                 devShell = mkProject { returnShellEnv = true; withHoogle = true; };
               }
             )

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -99,7 +99,7 @@ in
               in
               rec {
                 package = mkProject { };
-                app = { program = package; };
+                app = { type = "app"; program = package; };
                 devShell = mkProject { returnShellEnv = true; withHoogle = true; };
               }
             )


### PR DESCRIPTION
Fixes #8 