### PR TITLE
Remove automatic injection of `default` attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A [`flake-parts`](https://flake.parts/) Nix module for Haskell development.
       ];
       perSystem = { self', pkgs, ... }: {
         haskellProjects.default = {
-          name = "haskell-template";
           buildTools = hp: {
             fourmolu = hp.fourmolu;
           };

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A [`flake-parts`](https://flake.parts/) Nix module for Haskell development.
         haskell-flake.flakeModule
       ];
       perSystem = { self', pkgs, ... }: {
-        haskellProjects.my-haskell-package = {
+        haskellProjects.default = {
+          name = "haskell-template";
           buildTools = hp: {
             fourmolu = hp.fourmolu;
           };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -34,6 +34,7 @@ in
               name = mkOption {
                 type = types.str;
                 description = ''Name of the cabal package ("foo" if foo.cabal)'';
+                default = "";
               };
               root = mkOption {
                 type = types.path;
@@ -94,7 +95,7 @@ in
                 mkProject = { returnShellEnv ? false, withHoogle ? false }:
                   hp.developPackage {
                     inherit returnShellEnv withHoogle ;
-                    inherit (cfg) root source-overrides overrides;
+                    inherit (cfg) root name source-overrides overrides;
                     modifier = drv:
                       cfg.modifier (pkgs.haskell.lib.overrideCabal drv (oa: {
                         buildTools = (oa.buildTools or [ ]) ++ optionals returnShellEnv buildTools;


### PR DESCRIPTION
Resolves #10 

In lieu of this magic, we now allow arbitrary keys in projects attr set ... which keys are automatically propagated to `packages`, `apps` and `devShells`. This way the user can name their (only) project to be `default` and don't have to set them manually as defaults.