### PR TITLE
Make `buildTools` respect overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To keep `flake.nix` smaller (eg.: going from this [91-line flake.nix](https://gi
 }
 ```
 
-See [`flake-module.nix` -> `options`](flake-module.nix) for a list of options available. Uses [`developPackage`](https://github.com/NixOS/nixpkgs/blob/f1c167688a6f81f4a51ab542e5f476c8c595e457/pkgs/development/haskell-modules/make-package-set.nix#L245) under the hood, but see [#7](https://github.com/srid/haskell-flake/issues/7) for future improvements.
+See [`flake-module.nix` -> `options`](flake-module.nix) for a list of options available. Uses [`callCabal2nixWithOptions`](https://github.com/NixOS/nixpkgs/blob/f1c167688a6f81f4a51ab542e5f476c8c595e457/pkgs/development/haskell-modules/make-package-set.nix#L245) under the hood.  See [#7](https://github.com/srid/haskell-flake/issues/7) for future improvements.
 
 ## Template
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -137,9 +137,8 @@ in
               rec {
                 inherit package;
                 app = { type = "app"; program = pkgs.lib.getExe package; };
-                devShell = (pkgs.haskell.lib.overrideCabal package (oa: {
-                  buildTools = (oa.buildTools or [ ]) ++ buildTools;
-                })).envFunc { withHoogle = true; };
+                devShell = with pkgs.haskell.lib;
+                  (addBuildTools package buildTools).envFunc { withHoogle = true; };
                 checks =
                   lib.optionalAttrs cfg.enableHLSCheck {
                     "${projectKey}-hls" =


### PR DESCRIPTION
Resolves #22 

- [x] Test this PR
- [ ] Should we upstream `developPackageDrv` to nixpkgs? Probably worth waiting until #7 though
- [x] Refactor Nix
- [x] Update README (not using `developPackage` anymore)