### PR TITLE
Add a check for `hlint`; rename the HLS check option

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -97,7 +97,7 @@ in
                     };
                     dirs = mkOption {
                       type = types.listOf types.str;
-                      description = "Directories that should be checked with hlint";
+                      description = "Relative path strings from `root` to directories that should be checked with hlint";
                       default = [ "." ];
                     };
                   };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -174,7 +174,8 @@ in
                       "${projectKey}-hlint" =
                         runCommandInSimulatedShell
                           devShell
-                          cfg.root "${projectKey}-hlint-check"
+                          cfg.root
+                          "${projectKey}-hlint-check"
                           { buildInputs = [ pkgs.coreutils ]; }
                           ''
                             hlint ${lib.concatStringsSep " " cfg.hlintCheck.dirs}

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -178,6 +178,7 @@ in
                           { buildInputs = [ pkgs.coreutils ]; }
                           ''
                             hlint ${lib.concatStringsSep " " cfg.hlintCheck.dirs}
+                            touch $out
                           ''
                       ;
                     }

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -168,16 +168,19 @@ in
               rec {
                 inherit package devShell;
                 app = { type = "app"; program = pkgs.lib.getExe package; };
-                checks =
-                  (lib.optionalAttrs cfg.hlsCheck.enable {
-                    "${projectKey}-hls" = devShellCheck "hls" "haskell-language-server";
-                  }) // (
-                    lib.optionalAttrs cfg.hlintCheck.enable {
-                      "${projectKey}-hlint" = devShellCheck "hlint" ''
-                        hlint ${lib.concatStringsSep " " cfg.hlintCheck.dirs}
-                      '';
-                    }
-                  );
+                checks = lib.filterAttrs (_: v: v != null)
+                  {
+                    "${projectKey}-hls" =
+                      if cfg.hlsCheck.enable then
+                        devShellCheck "hls" "haskell-language-server"
+                      else null;
+                    "${projectKey}-hlint" =
+                      if cfg.hlintCheck.enable then
+                        devShellCheck "hlint" ''
+                          hlint ${lib.concatStringsSep " " cfg.hlintCheck.dirs}
+                        ''
+                      else null;
+                  };
               }
             )
             config.haskellProjects;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -93,12 +93,12 @@ in
                     enable = mkOption {
                       type = types.bool;
                       description = "Check whether hlint is enabled";
-                      default = false;  
+                      default = false;
                     };
                     dirs = mkOption {
                       type = types.listOf types.str;
                       description = "Directories that should be checked with hlint";
-                      default = [];
+                      default = [ "." ];
                     };
                   };
                 };
@@ -176,16 +176,10 @@ in
                           devShell
                           cfg.root "${projectKey}-hlint-check"
                           { buildInputs = [ pkgs.coreutils ]; }
-                          (
-                            let
-                              dirs = cfg.hlintCheck.dirs;
-                              defaultCmd = ''
-                                $(find . -name \*.hs | awk -F "/" '{print $2}')
-                              '';
-                            in ''
-                              hlint ${if dirs == [] then defaultCmd else lib.concatStringsSep " " dirs}
-                            ''
-                          );
+                          ''
+                            hlint ${lib.concatStringsSep " " cfg.hlintCheck.dirs}
+                          ''
+                      ;
                     }
                   );
               }

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -92,7 +92,7 @@ in
                   options = {
                     enable = mkOption {
                       type = types.bool;
-                      description = "Check whether hlint is enabled";
+                      description = "Whether to add a flake check to run hlint";
                       default = false;
                     };
                     dirs = mkOption {
@@ -125,7 +125,6 @@ in
 
               # Copy project root to a mutable area
               # We expect "command" to mutate it.
-              
               export HOME=$TMP
               cp -R ${projectRoot} $HOME/project
               chmod -R a+w $HOME/project

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -176,7 +176,7 @@ in
                           devShell
                           cfg.root
                           "${projectKey}-hlint-check"
-                          { buildInputs = [ pkgs.coreutils ]; }
+                          { }
                           ''
                             hlint ${lib.concatStringsSep " " cfg.hlintCheck.dirs}
                             touch $out

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -73,19 +73,26 @@ in
                 default = hp: { };
                 defaultText = ''Build tools useful for Haskell development are included by default.'';
               };
-              enableHLSCheck = mkOption {
-                type = types.bool;
-                description = ''
-                  Whether to enable a flake check to verify that HLS works.
+              hlsCheck = mkOption {
+                type = types.submodule {
+                  options = {
+                    enable = mkOption {
+                      type = types.bool;
+                      description = ''
+                        Whether to enable a flake check to verify that HLS works.
                   
-                  This is equivalent to `nix develop -i -c haskell-language-server`.
+                        This is equivalent to `nix develop -i -c haskell-language-server`.
 
-                  Note that, HLS will try to access the network through Cabal (see 
-                  https://github.com/haskell/haskell-language-server/issues/3128),
-                  therefore sandboxing must be disabled when evaluating this
-                  check.
-                '';
-                default = false;
+                        Note that, HLS will try to access the network through Cabal (see 
+                        https://github.com/haskell/haskell-language-server/issues/3128),
+                        therefore sandboxing must be disabled when evaluating this
+                        check.
+                      '';
+                      default = false;
+                    };
+
+                  };
+                };
               };
               hlintCheck = mkOption {
                 type = types.submodule {
@@ -162,7 +169,7 @@ in
                 inherit package devShell;
                 app = { type = "app"; program = pkgs.lib.getExe package; };
                 checks =
-                  (lib.optionalAttrs cfg.enableHLSCheck {
+                  (lib.optionalAttrs cfg.hlsCheck.enable {
                     "${projectKey}-hls" = devShellCheck "hls" "haskell-language-server";
                   }) // (
                     lib.optionalAttrs cfg.hlintCheck.enable {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -132,6 +132,7 @@ in
               pushd $HOME/project
 
               ${command}
+              touch $out
             '';
         projects =
           lib.mapAttrs
@@ -168,7 +169,6 @@ in
                         { }
                         ''
                           haskell-language-server
-                          touch $out
                         '';
                   }) // (
                     lib.optionalAttrs cfg.hlintCheck.enable {
@@ -180,7 +180,6 @@ in
                           { }
                           ''
                             hlint ${lib.concatStringsSep " " cfg.hlintCheck.dirs}
-                            touch $out
                           ''
                       ;
                     }

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -167,7 +167,8 @@ in
                         cfg.root "${projectKey}-hls-check"
                         { }
                         ''
-                          haskell-language-server > $out
+                          haskell-language-server
+                          touch $out
                         '';
                   }) // (
                     lib.optionalAttrs cfg.hlintCheck.enable {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -121,7 +121,7 @@ in
           pkgs.runCommand name (attrs // { nativeBuildInputs = devShell.nativeBuildInputs; })
             ''
               # Set pipefail option for safer bash
-              set -euxo pipefail
+              set -euo pipefail
 
               # Copy project root to a mutable area
               # We expect "command" to mutate it.


### PR DESCRIPTION
Closes #19

- Add `hlintCheck.enable` option (false by default); adds a flake check to run hlint
- Rename `enableHLSCheck` to `hlsCheck.enable` for consistency
- Internal: dev shell check no longer redirect to `$out` (instead, it simply touches it).