### PR TITLE
Replace `envFunc` with `shellFor`; make `name` mandatory

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -38,7 +38,6 @@ in
               name = mkOption {
                 type = types.str;
                 description = ''Name of the cabal package ("foo" if foo.cabal)'';
-                default = "";
               };
               root = mkOption {
                 type = types.path;
@@ -160,9 +159,12 @@ in
                 };
                 buildTools = lib.attrValues (defaultBuildTools hp // cfg.buildTools hp);
                 package = cfg.modifier (hp.callCabal2nixWithOptions cfg.name cfg.root "" { });
-                devShell = hp.shellFor {
+                devShell = (hp.extend (self: super: {
+                  # TODO: with or without modifier?
+                  "${cfg.name}" = package;
+                })).shellFor {
                   packages = p: [ 
-                    # Why do we need to add build tools?
+                    # TODO: Why do we need to add build tools?
                     (pkgs.haskell.lib.addBuildTools p."${cfg.name}" buildTools)
                   ];
                   withHoogle = true;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -158,14 +158,14 @@ in
                     hlint;
                 };
                 buildTools = lib.attrValues (defaultBuildTools hp // cfg.buildTools hp);
-                package = cfg.modifier (hp.callCabal2nixWithOptions cfg.name cfg.root "" { });
+                package' = hp.callCabal2nixWithOptions cfg.name cfg.root "" { };
+                package = cfg.modifier package';
                 devShell = (hp.extend (self: super: {
-                  # TODO: with or without modifier?
-                  "${cfg.name}" = package;
+                  "${cfg.name}" = package';
                 })).shellFor {
                   packages = p: [
                     # TODO: Why do we need to add build tools?
-                    (pkgs.haskell.lib.addBuildTools p."${cfg.name}" buildTools)
+                    (cfg.modifier (pkgs.haskell.lib.addBuildTools p."${cfg.name}" buildTools))
                   ];
                   withHoogle = true;
                   buildInputs = buildTools;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -163,7 +163,7 @@ in
                 devShell = hp.shellFor {
                   packages = p: [ 
                     # Why do we need to add build tools?
-                    (pkgs.haskell.lib.addBuildTools p.${cfg.name} buildTools)
+                    (pkgs.haskell.lib.addBuildTools p."${cfg.name}" buildTools)
                   ];
                   withHoogle = true;
                   buildInputs = buildTools;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -160,8 +160,16 @@ in
                 };
                 buildTools = lib.attrValues (defaultBuildTools hp // cfg.buildTools hp);
                 package = cfg.modifier (hp.callCabal2nixWithOptions cfg.name cfg.root "" { });
-                devShell = with pkgs.haskell.lib;
-                  (addBuildTools package buildTools).envFunc { withHoogle = true; };
+                devShell = hp.shellFor {
+                  packages = p: [ 
+                    # Why do we need to add build tools?
+                    (pkgs.haskell.lib.addBuildTools p.${cfg.name} buildTools)
+                  ];
+                  withHoogle = true;
+                  buildInputs = buildTools;
+                };
+                # devShell = with pkgs.haskell.lib;
+                #  (addBuildTools package buildTools).envFunc { withHoogle = true; };
                 devShellCheck = name: command:
                   runCommandInSimulatedShell devShell cfg.root "${projectKey}-${name}-check" { } command;
               in

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -164,8 +164,7 @@ in
                   "${cfg.name}" = package';
                 })).shellFor {
                   packages = p: [
-                    # TODO: Why do we need to add build tools?
-                    (cfg.modifier (pkgs.haskell.lib.addBuildTools p."${cfg.name}" buildTools))
+                    (cfg.modifier p."${cfg.name}")
                   ];
                   withHoogle = true;
                   buildInputs = buildTools;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -53,6 +53,7 @@ in
                 description = ''Overrides for the Cabal project'';
                 default = self: super: { };
               };
+              # TODO: This option will go away after #7
               modifier = mkOption {
                 type = functionTo types.package;
                 description = ''
@@ -169,8 +170,6 @@ in
                   withHoogle = true;
                   buildInputs = buildTools;
                 };
-                # devShell = with pkgs.haskell.lib;
-                #  (addBuildTools package buildTools).envFunc { withHoogle = true; };
                 devShellCheck = name: command:
                   runCommandInSimulatedShell devShell cfg.root "${projectKey}-${name}-check" { } command;
               in

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -163,7 +163,7 @@ in
                   # TODO: with or without modifier?
                   "${cfg.name}" = package;
                 })).shellFor {
-                  packages = p: [ 
+                  packages = p: [
                     # TODO: Why do we need to add build tools?
                     (pkgs.haskell.lib.addBuildTools p."${cfg.name}" buildTools)
                   ];


### PR DESCRIPTION
As one small step toward #7 

Also makes `name` optional mandatory because we need it to create the final package set. It will be implicitly necessary as part of #7 anyway.