### PR TITLE
Use `buildFromCabalSdist` on local packages

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -157,8 +157,11 @@ in
               let
                 inherit (pkgs.lib.lists) optionals;
                 localPackagesOverlay = self: _:
+                  let
+                    fromSdist = self.buildFromCabalSdist or (builtins.trace "Your version of Nixpkgs does not support hs.buildFromCabalSdist yet." (pkg: pkg));
+                  in
                   lib.mapAttrs
-                    (name: value: self.callCabal2nix name value.root { })
+                    (name: value: fromSdist (self.callCabal2nix name value.root { }))
                     cfg.packages;
                 finalOverlay =
                   pkgs.lib.composeManyExtensions


### PR DESCRIPTION
This catches incomplete release tarballs before they get out.
Closes #35 

It's unconditional and unconfigurable to keep it simple. Can adapt when there's a need.