### PR TITLE
Configure Hercules CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,5 +2,6 @@
   description = "A `flake-parts` module for Haskell development";
   outputs = { self, ... }: {
     flakeModule = ./flake-module.nix;
+    herculesCI.ciSystems = [ "x86_64-linux" "aarch64-darwin" ];
   };
 }


### PR DESCRIPTION
I believe `herculesCI.ciSystems` is mandatory to limit the building on these two systems (because that's all I have as agents).

https://docs.hercules-ci.com/hercules-ci-agent/evaluation/#_default_systems

Hercules CI will be used latter for testing #25 