### PR TITLE
Add `devShell` submodule; allow disabling dev environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for haskell-flake
 
+## `master` branch
+
+- #37: Group `buildTools` (renamed to `tools`), `hlsCheck` and `hlintCheck` under the `devShell` submodule option; and allow disabling them all using `devShell.enable = false;` (useful if you want haskell-flake to produce just the package outputs).
+
 ## 0.1.0
 
 - Initial release

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -12,12 +12,14 @@
         haskellProjects.default = {
           packages = {
             # You can add more than one local package here.
-            example.root = ./.;  # Assumes ./example.cabal
+            example.root = ./.; # Assumes ./example.cabal
           };
-          # buildTools = hp: { fourmolu = hp.fourmolu; ghcid = null; };
           # overrides = self: super: { };
-          # hlintCheck.enable = true;
-          # hlsCheck.enable = true;
+          # devShell = {
+          #  tools = hp: { fourmolu = hp.fourmolu; ghcid = null; };
+          #  hlintCheck.enable = true;
+          #  hlsCheck.enable = true;
+          # };
         };
         # haskell-flake doesn't set the default package, but you can do it here.
         packages.default = self'.packages.example;

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -16,6 +16,7 @@
           };
           # overrides = self: super: { };
           # devShell = {
+          #  enable = true;  # Enabled by default
           #  tools = hp: { fourmolu = hp.fourmolu; ghcid = null; };
           #  hlintCheck.enable = true;
           #  hlsCheck.enable = true;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -59,6 +59,41 @@ in
               };
             };
           };
+          devShellSubmodule = types.submodule {
+            options = {
+              enable = mkOption {
+                type = types.bool;
+                description = ''
+                  Whether to enable a development shell for the project.
+                '';
+                default = true;
+              };
+              tools = mkOption {
+                type = functionTo (types.attrsOf (types.nullOr types.package));
+                description = ''
+                  Build tools for developing the Haskell project.
+                '';
+                default = hp: { };
+                defaultText = ''
+                  Build tools useful for Haskell development are included by default.
+                '';
+              };
+              hlsCheck = mkOption {
+                default = { };
+                type = hlsCheckSubmodule;
+                description = ''
+                  A [check](flake-parts.html#opt-perSystem.checks) to make sure that your IDE will work.
+                '';
+              };
+              hlintCheck = mkOption {
+                default = { };
+                type = hlintCheckSubmodule;
+                description = ''
+                  A [check](flake-parts.html#opt-perSystem.checks) that runs [`hlint`](https://github.com/ndmitchell/hlint).
+                '';
+              };
+            };
+          };
           projectSubmodule = types.submodule {
             options = {
               haskellPackages = mkOption {
@@ -92,26 +127,6 @@ in
                 '';
                 default = self: super: { };
                 defaultText = lib.literalExpression "self: super: { }";
-              };
-              buildTools = mkOption {
-                type = functionTo (types.attrsOf (types.nullOr types.package));
-                description = ''Build tools for your Haskell package (available only in nix shell).'';
-                default = hp: { };
-                defaultText = ''Build tools useful for Haskell development are included by default.'';
-              };
-              hlsCheck = mkOption {
-                default = { };
-                type = hlsCheckSubmodule;
-                description = ''
-                  A [check](flake-parts.html#opt-perSystem.checks) to make sure that your IDE will work.
-                '';
-              };
-              hlintCheck = mkOption {
-                default = { };
-                type = hlintCheckSubmodule;
-                description = ''
-                  A [check](flake-parts.html#opt-perSystem.checks) that runs [`hlint`](https://github.com/ndmitchell/hlint).
-                '';
               };
               packages = mkOption {
                 type = types.lazyAttrsOf packageSubmodule;
@@ -180,7 +195,8 @@ in
                         pkgFiltered = pkgs.haskell.lib.overrideSrc pkgProto {
                           src = filterSrc name value.root;
                         };
-                      in fromSdist pkgFiltered)
+                      in
+                      fromSdist pkgFiltered)
                     cfg.packages;
                 finalOverlay =
                   pkgs.lib.composeManyExtensions

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -243,10 +243,9 @@ in
                   lib.mapAttrs
                     (name: _: finalPackages."${name}")
                     cfg.packages;
-                devShells = lib.optionalAttrs cfg.devShell.enable {
-                  "${projectKey}" = devShell;
-                };
-                checks = lib.optionalAttrs cfg.devShell.enable (lib.filterAttrs (_: v: v != null)
+              } // lib.optionalAttrs cfg.devShell.enable {
+                inherit devShell;
+                checks = lib.filterAttrs (_: v: v != null)
                   {
                     "${projectKey}-hls" =
                       if cfg.devShell.hlsCheck.enable then
@@ -258,7 +257,7 @@ in
                           hlint ${lib.concatStringsSep " " cfg.devShell.hlintCheck.dirs}
                         ''
                       else null;
-                  });
+                  };
               }
             )
             config.haskellProjects;
@@ -289,10 +288,9 @@ in
               (_: project: project.checks)
               projects);
         devShells =
-          lib.mkMerge
-            (lib.mapAttrsToList
-              (_: project: project.devShells)
-              projects);
+          lib.mapAttrs
+            (_: project: project.devShell)
+            projects;
       };
   };
 }

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,3 +1,5 @@
+set -e
+
 FLAKE=$(pwd)
 cd ./test
 # First, build the flake.

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -18,7 +18,7 @@
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
-      imports = [ 
+      imports = [
         inputs.haskell-flake.flakeModule
         inputs.check-flake.flakeModule
       ];
@@ -28,19 +28,21 @@
             # You can add more than one local package here.
             haskell-flake-test.root = ./.; # Assumes ./haskell-flake-test.cabal
           };
-          buildTools = hp: {
-            # Some buildTools are included by default. If you do not want them,
-            # set them to 'null' here.
-            ghcid = null;
-            # You can also add additional build tools.
-            fzf = pkgs.fzf;
-          };
           overrides = self: super: {
             # Custom library overrides (here, "foo" comes from a flake input)
             foo = self.callCabal2nix "foo" (inputs.haskell-multi-nix + /foo) { };
           };
-          hlintCheck.enable = true;
-          hlsCheck.enable = true;
+          devShell = {
+            tools = hp: {
+              # Some buildTools are included by default. If you do not want them,
+              # set them to 'null' here.
+              ghcid = null;
+              # You can also add additional build tools.
+              fzf = pkgs.fzf;
+            };
+            hlintCheck.enable = true;
+            hlsCheck.enable = true;
+          };
         };
         # haskell-flake doesn't set the default package, but you can do it here.
         packages.default = self'.packages.haskell-flake-test;


### PR DESCRIPTION
Resolves #37 (to be squash merged)

- Group `buildTools` (renamed to `tools`), `hlsCheck` and `hlintCheck` under the `devShell` submodule option
- Allow disabling them all using `devShell.enable = false;` (useful if you want haskell-flake to produce _just_ the package outputs).

cc @Kranzes