### PR TITLE
Make `overrides` an overlay type rather than a `functionTo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     - #64: Remove hlintCheck (use [treefmt-nix](https://github.com/numtide/treefmt-nix#flake-parts) instead)
     - #52: Expose the final package set as `finalPackages`. Rename `haskellPackages`, accordingly, to `basePackages`. Overlays are applied on top of `basePackage` -- using `source-overrides`, `overrides`, `packages` in that order -- to produce `finalPackages`.
     - #68: You can now use `imports` inside of `haskellProjects.<name>` to modularize your Haskell project configuration.
-      - #67: `overrides` will be combined using `composeManyExtensions`, however their order is arbitrary. This is experimental feature, and a warning will be logged.
+      - #67: `overrides` will be combined using `composeManyExtensions`, however their order is arbitrary. This is an experimental feature, and a warning will be logged.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     - #37: Group `buildTools` (renamed to `tools`), `hlsCheck` and `hlintCheck` under the `devShell` submodule option; and allow disabling them all using `devShell.enable = false;` (useful if you want haskell-flake to produce just the package outputs).
     - #64: Remove hlintCheck (use [treefmt-nix](https://github.com/numtide/treefmt-nix#flake-parts) instead)
     - #52: Expose the final package set as `finalPackages`. Rename `haskellPackages`, accordingly, to `basePackages`. Overlays are applied on top of `basePackage` -- using `source-overrides`, `overrides`, `packages` in that order -- to produce `finalPackages`.
+    - #68: You can now use `imports` inside of `haskellProjects.<name>` to modularize your Haskell project configuration.
+      - #67: `overrides` will be combined using `composeManyExtensions`, however their order is arbitrary. This is experimental feature, and a warning will be logged.
 
 ## 0.1.0
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -114,7 +114,18 @@ in
                         # returns an attrset.
                         check = lib.isFunction;
                         merge = _loc: defs:
-                          lib.composeManyExtensions (map (x: x.value) defs);
+                          let
+                            logWarning =
+                              if builtins.length defs > 1
+                              then builtins.trace "WARNING[haskel-flake]: Multiple haskell overlays are applied in arbitrary order." null
+                              else null;
+                            overlays =
+                              map (x: x.value)
+                                (builtins.seq
+                                  logWarning
+                                  defs);
+                          in
+                          lib.composeManyExtensions overlays;
                       };
                     in
                     mkOption {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -101,22 +101,38 @@ in
                   };
                   overrides =
                     let
-                      haskellOverlay = types.mkOptionType {
+                      # WARNING: While the deterministic, it is not determined
+                      # by the user. Thus overlays may be applied in unexpected
+                      # order.
+                      # We need: https://github.com/NixOS/nixpkgs/issues/215486
+                      haskellOverlayType = types.mkOptionType {
                         name = "haskellOverlay";
-                        description = "Haskell overlay function";
+                        description = "An Haskell overlay function";
                         descriptionClass = "noun";
+                        # NOTE: This check is not exhaustive, as there is no way
+                        # to check that the function takes two arguments, and
+                        # returns an attrset.
                         check = lib.isFunction;
-                        merge = loc: defs:
-                          # TODO: What to do with loc?
+                        merge = _loc: defs:
                           lib.composeManyExtensions (map (x: x.value) defs);
                       };
                     in
                     mkOption {
-                      type = haskellOverlay;
+                      type = haskellOverlayType;
                       description = ''
-                        Overrides for the Cabal project
+                        Cabal package overrides for this Haskell project
                 
-                        For handy functions, see <https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib/compose.nix>
+                        For handy functions, see 
+                        <https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib/compose.nix>
+
+                        **WARNING**: When using `imports`, multiple overlays
+                        *will be merged using `lib.composeManyExtensions`.
+                        *However the order the overlays are applied can be
+                        *arbitrary (albeit deterministic, based on module system
+                        *implementation).  Thus, the use of `overrides` via
+                        *`imports` is not officiallly supported. If you'd like
+                        *to see proper support, add your thumbs up to
+                        <https://github.com/NixOS/nixpkgs/issues/215486>.
                       '';
                       default = self: super: { };
                       defaultText = lib.literalExpression "self: super: { }";

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -101,9 +101,9 @@ in
                   };
                   overrides =
                     let
-                      # WARNING: While the deterministic, it is not determined
-                      # by the user. Thus overlays may be applied in unexpected
-                      # order.
+                      # WARNING: While the order is deterministic, it is not
+                      # determined by the user. Thus overlays may be applied in
+                      # an unexpected order.
                       # We need: https://github.com/NixOS/nixpkgs/issues/215486
                       haskellOverlayType = types.mkOptionType {
                         name = "haskellOverlay";
@@ -117,7 +117,7 @@ in
                           let
                             logWarning =
                               if builtins.length defs > 1
-                              then builtins.trace "WARNING[haskel-flake]: Multiple haskell overlays are applied in arbitrary order." null
+                              then builtins.trace "WARNING[haskell-flake]: Multiple haskell overlays are applied in arbitrary order." null
                               else null;
                             overlays =
                               map (x: x.value)
@@ -137,12 +137,12 @@ in
                         <https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib/compose.nix>
 
                         **WARNING**: When using `imports`, multiple overlays
-                        *will be merged using `lib.composeManyExtensions`.
-                        *However the order the overlays are applied can be
-                        *arbitrary (albeit deterministic, based on module system
-                        *implementation).  Thus, the use of `overrides` via
-                        *`imports` is not officiallly supported. If you'd like
-                        *to see proper support, add your thumbs up to
+                        will be merged using `lib.composeManyExtensions`.
+                        However the order the overlays are applied can be
+                        arbitrary (albeit deterministic, based on module system
+                        implementation).  Thus, the use of `overrides` via
+                        `imports` is not officiallly supported. If you'd like
+                        to see proper support, add your thumbs up to
                         <https://github.com/NixOS/nixpkgs/issues/215486>.
                       '';
                       default = self: super: { };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -99,16 +99,28 @@ in
                     description = ''Package overrides given new source path'';
                     default = { };
                   };
-                  overrides = mkOption {
-                    type = functionTo (functionTo (types.lazyAttrsOf raw));
-                    description = ''
-                      Overrides for the Cabal project
+                  overrides =
+                    let
+                      haskellOverlay = types.mkOptionType {
+                        name = "haskellOverlay";
+                        description = "Haskell overlay function";
+                        descriptionClass = "noun";
+                        check = lib.isFunction;
+                        merge = loc: defs:
+                          # TODO: What to do with loc?
+                          lib.composeManyExtensions (map (x: x.value) defs);
+                      };
+                    in
+                    mkOption {
+                      type = haskellOverlay;
+                      description = ''
+                        Overrides for the Cabal project
                 
-                      For handy functions, see <https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib/compose.nix>
-                    '';
-                    default = self: super: { };
-                    defaultText = lib.literalExpression "self: super: { }";
-                  };
+                        For handy functions, see <https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib/compose.nix>
+                      '';
+                      default = self: super: { };
+                      defaultText = lib.literalExpression "self: super: { }";
+                    };
                   packages = mkOption {
                     type = types.lazyAttrsOf packageSubmodule;
                     description = ''

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -28,6 +28,11 @@
           imports =
             let
               defaults = {
+                overrides = self: super: {
+                  # This is purposefully incorrect (pointing to ./.) because we
+                  # expect it to be overriden below.
+                  foo = self.callCabal2nix "foo" ./. { };
+                };
                 devShell = {
                   tools = hp: {
                     # Setting to null should remove this tool from defaults.
@@ -39,7 +44,9 @@
             in
             [ defaults ];
           overrides = self: super: {
-            # Custom library overrides (here, "foo" comes from a flake input)
+            # This overrides the overlay above (in `defaults`), because the
+            # module system merges them in such order. cf. the WARNING in option
+            # docs.
             foo = self.callCabal2nix "foo" (inputs.haskell-multi-nix + /foo) { };
           };
           devShell.tools = hp: {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -24,16 +24,14 @@
       ];
       perSystem = { self', pkgs, ... }: {
         haskellProjects.default = {
+          # Multiple modules should be merged correctly.
           imports =
             let
               defaults = {
                 devShell = {
                   tools = hp: {
-                    # Some buildTools are included by default. If you do not want them,
-                    # set them to 'null' here.
+                    # Setting to null should remove this tool from defaults.
                     ghcid = null;
-                    # You can also add additional build tools.
-                    fzf = pkgs.fzf;
                   };
                   hlsCheck.enable = true;
                 };
@@ -43,6 +41,10 @@
           overrides = self: super: {
             # Custom library overrides (here, "foo" comes from a flake input)
             foo = self.callCabal2nix "foo" (inputs.haskell-multi-nix + /foo) { };
+          };
+          devShell.tools = hp: {
+            # Adding a tool should make it available in devshell.
+            fzf = pkgs.fzf;
           };
         };
         # haskell-flake doesn't set the default package, but you can do it here.

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -24,19 +24,25 @@
       ];
       perSystem = { self', pkgs, ... }: {
         haskellProjects.default = {
+          imports =
+            let
+              defaults = {
+                devShell = {
+                  tools = hp: {
+                    # Some buildTools are included by default. If you do not want them,
+                    # set them to 'null' here.
+                    ghcid = null;
+                    # You can also add additional build tools.
+                    fzf = pkgs.fzf;
+                  };
+                  hlsCheck.enable = true;
+                };
+              };
+            in
+            [ defaults ];
           overrides = self: super: {
             # Custom library overrides (here, "foo" comes from a flake input)
             foo = self.callCabal2nix "foo" (inputs.haskell-multi-nix + /foo) { };
-          };
-          devShell = {
-            tools = hp: {
-              # Some buildTools are included by default. If you do not want them,
-              # set them to 'null' here.
-              ghcid = null;
-              # You can also add additional build tools.
-              fzf = pkgs.fzf;
-            };
-            hlsCheck.enable = true;
           };
         };
         # haskell-flake doesn't set the default package, but you can do it here.


### PR DESCRIPTION
A step towards #12

- [x] proof of concept https://github.com/srid/haskell-template/pull/85
- [x] new overlay option type
  - [x] make it mergeable
  - [x] finish mkOption implementation (`loc`, etc.)
- [x] test mergeability of other options (`devShell.tools`, `source-overrides`, etc.)
- [ ] how to publish these modules?[^r]
- [x] docs & changelog
- [x] proper tests

[^r]: From @roberth on [Matrix](https://matrix.to/#/!gcrYWdPsIUOFpXFDHB:matrix.org/$ZOYhSXRWLJne7vr9Wz0FkZV27eOzrSa9dRP8LALV2mM?via=matrix.org&via=nixos.dev&via=gaze.systems):
    > I think what's missing from the picture is a flake attribute for publishing those modules, and setting up the module arguments for those modules so that they don't have to rely on variables from the lexical scope. The lexical scope is too specific to the local project, not including things like the consuming project's pkgs and whatnot [..] oh and for publishing a module, you can use `types.deferredModule`, which is takes modules, turns them into a single module, but does cause them to be evaluated; returning a module syntax instead of an evaluated configuration