### PR TITLE
Added templates.flake-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ To use `haskell-flake` in your Haskell projects, run:
 nix flake init -t github:srid/haskell-flake
 ```
 
-This will generate a template Haskell project with a `flake.nix`. If you already have a Haskell project, copy over this `flake.nix` and adjust accordingly.
+This will generate a template Haskell project with a `flake.nix`. If you already have a Haskell project, run:
+
+
+``` nix
+nix flake init -t github:srid/haskell-flake#flake-only
+```
+
+and adjust accordingly.
 
 ### Template
 

--- a/flake.nix
+++ b/flake.nix
@@ -6,5 +6,9 @@
       description = "Example project using haskell-flake";
       path = ./example;
     };
+    templates.flake-only = {
+      description = "Example flake using haskell-flake";
+      path = builtins.path {path=./example; filter = path: _: baseNameOf path == "flake.nix";};
+    };
   };
 }


### PR DESCRIPTION
Closes #66 

Already existing Haskell projects can use this template to avoid creating _example.cabal_ and _src/Main.hs_ during initialization.