### PR TITLE
README.md: added a \n at the end of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ Check out the [list of options](https://flake.parts/options/haskell-flake.html).
 ## Recommendations
 
 - Use [`treefmt-nix`](https://github.com/numtide/treefmt-nix#flake-parts) for providing linting features like auto-formatting and hlint checks. See [haskell-template](https://github.com/srid/haskell-template) for example.
+


### PR DESCRIPTION
Git will show the last line as changed every time a change is made to `README.md`, with the following message : `\ No newline at end of file`
The alternative for this will be to use `git add -p` to choose which hunk gets staged, but that could add up some manual work.

This problem could be specific to unix/linux (not sure)