### PR TITLE
Keep all project config in haskell-project.nix

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -72,25 +72,6 @@ in
             };
           };
           projectSubmodule = types.submoduleWith { specialArgs = { inherit pkgs self; }; modules = [ ./haskell-project.nix (args@{ name, config, lib, ... }:
-          let
-            localPackagesOverlay = self: _:
-              let
-                fromSdist = self.buildFromCabalSdist or (builtins.trace "Your version of Nixpkgs does not support hs.buildFromCabalSdist yet." (pkg: pkg));
-                filterSrc = name: src: lib.cleanSourceWith { inherit src name; filter = path: type: true; };
-              in
-              lib.mapAttrs
-                (name: value:
-                  let
-                    # callCabal2nix does not need a filtered source. It will
-                    # only pick out the cabal and/or hpack file.
-                    pkgProto = self.callCabal2nix name value.root { };
-                    pkgFiltered = pkgs.haskell.lib.overrideSrc pkgProto {
-                      src = filterSrc name value.root;
-                    };
-                  in
-                  fromSdist pkgFiltered)
-                config.packages;
-          in
           {
             options = {
               haskellPackages = mkOption {
@@ -170,20 +151,6 @@ in
                 internal = true;
               };
             };
-            config = {
-                finalPackages = config.haskellPackages.extend config.finalOverlay;
-
-                finalOverlay = lib.composeManyExtensions [
-                  # The order here matters.
-                  #
-                  # User's overrides (cfg.overrides) is applied **last** so
-                  # as to give them maximum control over the final package
-                  # set used.
-                  localPackagesOverlay
-                  (pkgs.haskell.lib.packageSourceOverrides config.source-overrides)
-                  config.overrides
-                ];
-              };
           }) ]; };
         in
         {

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -25,7 +25,8 @@ let
       '';
 in
 {
-  config.outputs =
+
+  config =
     let
       projectKey = name;
 
@@ -78,29 +79,44 @@ in
       };
     in
     {
-      packages =
-        let
-          mapKeys = f: attrs: lib.mapAttrs' (n: v: { name = f n; value = v; }) attrs;
-          # Prefix package names with the project name (unless
-          # project is named `default`)
-          dropDefaultPrefix = packageName:
-            if projectKey == "default"
-            then packageName
-            else "${projectKey}-${packageName}";
-        in
-        mapKeys dropDefaultPrefix
-          (lib.mapAttrs
-            (name: _: finalPackages."${name}")
-            config.packages);
+      finalPackages = config.haskellPackages.extend config.finalOverlay;
 
-      devShells."${projectKey}" = devShell;
+      finalOverlay = lib.composeManyExtensions [
+        # The order here matters.
+        #
+        # User's overrides (cfg.overrides) is applied **last** so
+        # as to give them maximum control over the final package
+        # set used.
+        localPackagesOverlay
+        (pkgs.haskell.lib.packageSourceOverrides config.source-overrides)
+        config.overrides
+      ];
 
-    } // lib.optionalAttrs config.devShell.hlsCheck.enable {
+      outputs = {
+        packages =
+          let
+            mapKeys = f: attrs: lib.mapAttrs' (n: v: { name = f n; value = v; }) attrs;
+            # Prefix package names with the project name (unless
+            # project is named `default`)
+            dropDefaultPrefix = packageName:
+              if projectKey == "default"
+              then packageName
+              else "${projectKey}-${packageName}";
+          in
+          mapKeys dropDefaultPrefix
+            (lib.mapAttrs
+              (name: _: finalPackages."${name}")
+              config.packages);
 
-      checks."${projectKey}-hls" =
-        runCommandInSimulatedShell
-          devShell
-          self "${projectKey}-hls-check"
-          { } "haskell-language-server";
+        devShells."${projectKey}" = devShell;
+
+      } // lib.optionalAttrs config.devShell.hlsCheck.enable {
+
+        checks."${projectKey}-hls" =
+          runCommandInSimulatedShell
+            devShell
+            self "${projectKey}-hls-check"
+            { } "haskell-language-server";
+      };
     };
 }


### PR DESCRIPTION
@roberth What do you think? The entirety of `haskell-project.nix` continues to remain responsible for creating the `config` implementation for `haskellProjects.foo`

