### PR TITLE
Deduplicate `finalPackages`

### DIFF
--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -28,6 +28,8 @@ in
 
   config =
     let
+      inherit (config) finalPackages;
+
       projectKey = name;
 
       localPackagesOverlay = self: _:
@@ -47,19 +49,6 @@ in
             in
             fromSdist pkgFiltered)
           config.packages;
-      finalOverlay =
-        lib.composeManyExtensions
-          [
-            # The order here matters.
-            #
-            # User's overrides (cfg.overrides) is applied **last** so
-            # as to give them maximum control over the final package
-            # set used.
-            localPackagesOverlay
-            (pkgs.haskell.lib.packageSourceOverrides config.source-overrides)
-            config.overrides
-          ];
-      finalPackages = config.haskellPackages.extend finalOverlay;
 
       defaultBuildTools = hp: with hp; {
         inherit


### PR DESCRIPTION
After moving code around, I think I accidentally duplicated the implementation of finalPackages, which has lead to the problem:

> It looks like `readonly` has no effect, because I can still set `finalPackages.foo = ./.;` (even `finalPackages = ./.;`) in `test/flake.nix`?

With this fix, it reports:

    error: The option `perSystem.x86_64-linux.haskellProjects.default.finalPackages' is read-only, but it's set multiple times. Definition values:
           - In `/nix/store/n0vj61wy18j094y6gpzjvq5g0w63d637-source/flake.nix, via option perSystem'
           - In `/nix/store/yp9drmdqfgq74c5ap90cq9jqis4yiw41-source/haskell-project.nix'

I suspect that it happened when I did a

    git checkout <rev> haskell-project.nix

at some point, with the goal of easily minimizing the diff. That was probably inaccurate.