### PR TITLE
added shellHook option to devShell

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -69,6 +69,13 @@ in
                   A [check](flake-parts.html#opt-perSystem.checks) to make sure that your IDE will work.
                 '';
               };
+              shellHook = mkOption {
+                default = "";
+                type = types.str;
+                description = ''
+                  Bash statements that are executed by nix develop.
+                '';
+              };
             };
           };
           projectSubmodule = types.submoduleWith {

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -65,6 +65,7 @@ in
             (name: p."${name}")
             (lib.attrNames config.packages);
         withHoogle = true;
+        shellHook = config.devShell.shellHook;
       };
     in
     {


### PR DESCRIPTION
when i first tried flake parts, i tried to use haskell flake but i needed shellHook so i ended up not using it, however the only problem for me is the lack of a shellHook. I recently thought wait couldn't i just add a shellHook option?