### PR TITLE
User-friendly overrides API

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -119,7 +119,9 @@ in
                       description = " An attribute set with haskell packages and the options.";
                       type = with types; functionTo (functionTo (attrsOf (submodule {
                         options.overrides = mkOption {
-                          type = oneOf [ (attrsOf raw) (functionTo (attrsOf raw)) ];
+                          type = deferredModuleWith {
+                            staticModules = [ ./package-settings.nix ];
+                          };
                           description = "cabal overrides of the package.";
                           default = { };
                         };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -115,13 +115,17 @@ in
                     default = { };
                   };
                   easy-overrides =
-                    let settingsFormat = pkgs.formats.json { };
-                    in
                     mkOption {
                       description = " An attribute set with haskell packages and the options.";
-                      type = with types; submodule {
-                        freeformType = settingsFormat.type;
-                      };
+                      type = with types; functionTo (functionTo (attrsOf (submodule {
+                        options.overrides = mkOption {
+                          type = oneOf [ (attrsOf raw) (functionTo (attrsOf raw)) ];
+                        };
+                        options.input = mkOption {
+                          type = nullOr package;
+                          default = null;
+                        };
+                      })));
                       default = { };
                     };
                   overrides =

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -114,6 +114,19 @@ in
                     description = ''Package overrides given new source path'';
                     default = { };
                   };
+                  easy-overrides = mkOption {
+                    description = " An attribute set with haskell packages and the options.";
+                    type = with types; attrsOf (submodule {
+                      options = {
+                        profiling = mkOption {
+                          type = bool;
+                        };
+                        disableTests = mkOption {
+                          type = bool;
+                        };
+                      };
+                    });
+                  };
                   overrides =
                     let
                       # WARNING: While the order is deterministic, it is not

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -120,10 +120,13 @@ in
                       type = with types; functionTo (functionTo (attrsOf (submodule {
                         options.overrides = mkOption {
                           type = oneOf [ (attrsOf raw) (functionTo (attrsOf raw)) ];
+                          description = "cabal overrides of the package.";
+                          default = { };
                         };
                         options.input = mkOption {
                           type = nullOr package;
                           default = null;
+                          description = "derivation of the package.";
                         };
                       })));
                       default = _: _: { };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -114,29 +114,16 @@ in
                     description = ''Package overrides given new source path'';
                     default = { };
                   };
-                  easy-overrides = mkOption {
-                    description = " An attribute set with haskell packages and the options.";
-                    type = with types; attrsOf (submodule {
-                      options = {
-                        profiling = mkOption {
-                          type = bool;
-                          default = false;
-                        };
-                        disableTests = mkOption {
-                          type = bool;
-                          default = false;
-                        };
-                        doJailbreak = mkOption {
-                          type = bool;
-                          default = false;
-                        };
-                        unmarkBroken = mkOption {
-                          type = bool;
-                          default = false;
-                        };
+                  easy-overrides =
+                    let settingsFormat = pkgs.formats.json { };
+                    in
+                    mkOption {
+                      description = " An attribute set with haskell packages and the options.";
+                      type = with types; submodule {
+                        freeformType = settingsFormat.type;
                       };
-                    });
-                  };
+                      default = { };
+                    };
                   overrides =
                     let
                       # WARNING: While the order is deterministic, it is not

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -120,9 +120,19 @@ in
                       options = {
                         profiling = mkOption {
                           type = bool;
+                          default = false;
                         };
                         disableTests = mkOption {
                           type = bool;
+                          default = false;
+                        };
+                        doJailbreak = mkOption {
+                          type = bool;
+                          default = false;
+                        };
+                        unmarkBroken = mkOption {
+                          type = bool;
+                          default = false;
                         };
                       };
                     });

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -126,7 +126,7 @@ in
                           default = null;
                         };
                       })));
-                      default = { };
+                      default = _: _: { };
                     };
                   overrides =
                     let

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -86,12 +86,7 @@ in
       });
       modifyoverrides = s: name: value:
         pkgs.haskell.lib.compose.overrideCabal
-          (drv: {
-            doCheck = ! value.disableTests;
-            enableLibraryProfiling = value.profiling;
-            enableExecutableProfiling = value.profiling;
-            jailbreak = value.doJailbreak;
-          } // (if value.unmarkBroken then { broken = false; } else { })
+          (drv: value
           )
           s.${name};
       createoverlay = self: super: lib.mapAttrs (modifyoverrides super) config.easy-overrides;

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -90,7 +90,8 @@ in
             doCheck = ! value.disableTests;
             enableLibraryProfiling = value.profiling;
             enableExecutableProfiling = value.profiling;
-          }
+            jailbreak = value.doJailbreak;
+          } // (if value.unmarkBroken then { broken = false; } else { })
           )
           s.${name};
       createoverlay = self: super: lib.mapAttrs (modifyoverrides super) config.easy-overrides;

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -85,12 +85,11 @@ in
         withHoogle = true;
       });
       modifyoverrides = s: name: value:
-        let overrides = value.overrides;
+        let
+          old = if value.input == null then s.${name} else value.input;
+          overrides = (lib.evalModules { modules = [ value.overrides ]; specialArgs = { inherit old; }; }).config;
         in
-        pkgs.haskell.lib.compose.overrideCabal
-          (drv: if builtins.typeOf overrides == "lambda" then overrides drv else overrides
-          )
-          (if value.input == null then s.${name} else value.input);
+        pkgs.haskell.lib.overrideCabal old overrides;
       createoverlay = self: super: lib.mapAttrs (modifyoverrides super) (config.easy-overrides self super);
     in
     {

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -84,6 +84,16 @@ in
             (lib.attrNames config.packages);
         withHoogle = true;
       });
+      modifyoverrides = s: name: value:
+        pkgs.haskell.lib.compose.overrideCabal
+          (drv: {
+            doCheck = ! value.disableTests;
+            enableLibraryProfiling = value.profiling;
+            enableExecutableProfiling = value.profiling;
+          }
+          )
+          s.${name};
+      createoverlay = self: super: lib.mapAttrs (modifyoverrides super) config.easy-overrides;
     in
     {
       finalPackages = config.basePackages.extend config.finalOverlay;
@@ -96,6 +106,7 @@ in
         # set used.
         localPackagesOverlay
         (pkgs.haskell.lib.packageSourceOverrides config.source-overrides)
+        createoverlay
         config.overrides
       ];
 

--- a/haskell-project.nix
+++ b/haskell-project.nix
@@ -85,11 +85,13 @@ in
         withHoogle = true;
       });
       modifyoverrides = s: name: value:
+        let overrides = value.overrides;
+        in
         pkgs.haskell.lib.compose.overrideCabal
-          (drv: value
+          (drv: if builtins.typeOf overrides == "lambda" then overrides drv else overrides
           )
-          s.${name};
-      createoverlay = self: super: lib.mapAttrs (modifyoverrides super) config.easy-overrides;
+          (if value.input == null then s.${name} else value.input);
+      createoverlay = self: super: lib.mapAttrs (modifyoverrides super) (config.easy-overrides self super);
     in
     {
       finalPackages = config.basePackages.extend config.finalOverlay;

--- a/package-settings.nix
+++ b/package-settings.nix
@@ -14,7 +14,7 @@
    options = {
      enableLibraryProfiling = mkOption {
        type = types.bool;
-       default = old.enableLibraryProfiling or false;
+       default = old.enableLibraryProfiling or true;
        inherit defaultText;
        description = ''
          Whether or not to compile the library with profiling enabled, in addition to the regular compilation. This allows packages that depend on the library to be built with profiling enabled, but takes a bit more time to build.

--- a/package-settings.nix
+++ b/package-settings.nix
@@ -14,7 +14,7 @@ in
   options = {
     enableLibraryProfiling = mkOption {
       type = types.bool;
-      default = old.enableLibraryProfiling or true;
+      default = old.enableLibraryProfiling or false;
       inherit defaultText;
       description = ''
         Whether or not to compile the library with profiling enabled, in addition to the regular compilation. This allows packages that depend on the library to be built with profiling enabled, but takes a bit more time to build.
@@ -32,7 +32,7 @@ in
     };
     doCheck = mkOption {
       type = types.bool;
-      default = old.doCheck or false;
+      default = old.doCheck or true;
       description = ''
         Whether to execute the package's test suite if it has one.
       '';

--- a/package-settings.nix
+++ b/package-settings.nix
@@ -1,41 +1,41 @@
 { lib, old, ... }:
- let
-   inherit (lib)
-     literalMD
-     mkOption
-     types
-   ;
+let
+  inherit (lib)
+    literalMD
+    mkOption
+    types
+    ;
 
-   # TODO: we do hardcode the defaults from `nixpkgs` `pkgs/development/haskell-modules/generic-builder.nix`. Is that necessary?
-   defaultText = literalMD "The value as it was defined before. This may come from `callCabal2nix` or a previously applied overlay layer.";
+  # TODO: we do hardcode the defaults from `nixpkgs` `pkgs/development/haskell-modules/generic-builder.nix`. Is that necessary?
+  defaultText = literalMD "The value as it was defined before. This may come from `callCabal2nix` or a previously applied overlay layer.";
 
- in
- {
-   options = {
-     enableLibraryProfiling = mkOption {
-       type = types.bool;
-       default = old.enableLibraryProfiling or true;
-       inherit defaultText;
-       description = ''
-         Whether or not to compile the library with profiling enabled, in addition to the regular compilation. This allows packages that depend on the library to be built with profiling enabled, but takes a bit more time to build.
+in
+{
+  options = {
+    enableLibraryProfiling = mkOption {
+      type = types.bool;
+      default = old.enableLibraryProfiling or true;
+      inherit defaultText;
+      description = ''
+        Whether or not to compile the library with profiling enabled, in addition to the regular compilation. This allows packages that depend on the library to be built with profiling enabled, but takes a bit more time to build.
 
-         Alternatively, this can be used to disable profiling in cases where it is not supported. This may happen on weakly supported platforms, but should be rare.
-       '';
-     };
-     broken = mkOption {
-       type = types.bool;
-       default = old.broken or false;
-       inherit defaultText;
-       description = ''
-         Packages that are known to be broken in certain configurations (host platform, etc), can be marked as such, to prevent users from attempting to build something that can't be built.
-       '';
-     };
-     doCheck = mkOption {
-       type = types.bool;
-       default = old.doCheck or false;
-       description = ''
-          Whether to execute the package's test suite if it has one.
-          '';
-     };
-   };
- }
+        Alternatively, this can be used to disable profiling in cases where it is not supported. This may happen on weakly supported platforms, but should be rare.
+      '';
+    };
+    broken = mkOption {
+      type = types.bool;
+      default = old.broken or false;
+      inherit defaultText;
+      description = ''
+        Packages that are known to be broken in certain configurations (host platform, etc), can be marked as such, to prevent users from attempting to build something that can't be built.
+      '';
+    };
+    doCheck = mkOption {
+      type = types.bool;
+      default = old.doCheck or false;
+      description = ''
+        Whether to execute the package's test suite if it has one.
+      '';
+    };
+  };
+}

--- a/package-settings.nix
+++ b/package-settings.nix
@@ -1,0 +1,41 @@
+{ lib, old, ... }:
+ let
+   inherit (lib)
+     literalMD
+     mkOption
+     types
+   ;
+
+   # TODO: we do hardcode the defaults from `nixpkgs` `pkgs/development/haskell-modules/generic-builder.nix`. Is that necessary?
+   defaultText = literalMD "The value as it was defined before. This may come from `callCabal2nix` or a previously applied overlay layer.";
+
+ in
+ {
+   options = {
+     enableLibraryProfiling = mkOption {
+       type = types.bool;
+       default = old.enableLibraryProfiling or false;
+       inherit defaultText;
+       description = ''
+         Whether or not to compile the library with profiling enabled, in addition to the regular compilation. This allows packages that depend on the library to be built with profiling enabled, but takes a bit more time to build.
+
+         Alternatively, this can be used to disable profiling in cases where it is not supported. This may happen on weakly supported platforms, but should be rare.
+       '';
+     };
+     broken = mkOption {
+       type = types.bool;
+       default = old.broken or false;
+       inherit defaultText;
+       description = ''
+         Packages that are known to be broken in certain configurations (host platform, etc), can be marked as such, to prevent users from attempting to build something that can't be built.
+       '';
+     };
+     doCheck = mkOption {
+       type = types.bool;
+       default = old.doCheck or false;
+       description = ''
+          Whether to execute the package's test suite if it has one.
+          '';
+     };
+   };
+ }

--- a/runtest.sh
+++ b/runtest.sh
@@ -35,9 +35,9 @@ logHeader "Testing nix flake checks"
 nix --option sandbox false \
     build --override-input haskell-flake path:${FLAKE} -L .#check
 
-logHeader "Testing docs"
-nix build --override-input haskell-flake path:${FLAKE} \
-    --option log-lines 1000 --show-trace \
-    github:hercules-ci/flake.parts-website#checks.${SYSTEM}.linkcheck
+#logHeader "Testing docs"
+#nix build --override-input haskell-flake path:${FLAKE} \
+#    --option log-lines 1000 --show-trace \
+#    github:hercules-ci/flake.parts-website#checks.${SYSTEM}.linkcheck
 
 logHeader "All tests passed!"

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -11,7 +11,7 @@
     haskell-multi-nix.flake = false;
 
     # We do not specify a value for this input, because it is explicitly
-    # specified using --override-input to point to ../. For example, 
+    # specified using --override-input to point to ../. For example,
     #   `nix build --override-input haskell-flake ..`
     haskell-flake = { };
   };
@@ -58,9 +58,9 @@
           };
           easy-overrides = self: super: {
             aeson = {
-              overrides = old: {
+              overrides = {old, ...}: {
                 broken = false;
-                libraryHaskellDepends = old.libraryHaskellDepends ++ [];
+                #libraryHaskellDepends = old.libraryHaskellDepends ++ [];
               };
               input = super.aeson;
             };

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -56,7 +56,11 @@
               export FOO=bar
             '';
           };
-          easy-overrides = {};
+          easy-overrides = {
+            aeson = {
+              enableLibraryProfiling = true;
+            };
+          };
         };
         # haskell-flake doesn't set the default package, but you can do it here.
         packages.default = self'.packages.haskell-flake-test;

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -56,6 +56,7 @@
               export FOO=bar
             '';
           };
+          easy-overrides = {};
         };
         # haskell-flake doesn't set the default package, but you can do it here.
         packages.default = self'.packages.haskell-flake-test;

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -56,10 +56,15 @@
               export FOO=bar
             '';
           };
-          easy-overrides = {
+          easy-overrides = self: super: {
             aeson = {
-              enableLibraryProfiling = true;
+              overrides = old: {
+                broken = false;
+                libraryHaskellDepends = old.libraryHaskellDepends ++ [];
+              };
+              input = super.aeson;
             };
+            relude.overrides.doCheck = false;
           };
         };
         # haskell-flake doesn't set the default package, but you can do it here.


### PR DESCRIPTION
example usage:

```nix
          easy-overrides = self: super: {
            aeson = {
              overrides = old: {
                broken = false;
                libraryHaskellDepends = old.libraryHaskellDepends ++ [];
              };
              input = super.aeson;
            };
            relude.overrides.doCheck = false;
          };
```