### PR TITLE
Simplify .cabal files detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - New features
   - #63: Add `config.haskellProjects.${name}.outputs` containing all flake outputs for that project.
-  - #49: The `packages` option now autodiscovers the top-level `.cabal` file as its default value.
+  - #49 & #91: The `packages` option now autodiscovers the top-level `.cabal` file (in addition to looking inside sub-directories) as its default value.
   - #69: The default flake template creates `flake.nix` only, while the `#example` one creates the full Haskell project template.
 - API changes
     - #37: Group `buildTools` (renamed to `tools`), `hlsCheck` and `hlintCheck` under the `devShell` submodule option; and allow disabling them all using `devShell.enable = false;` (useful if you want haskell-flake to produce just the package outputs).

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -177,10 +177,9 @@ in
                             (builtins.readDir path));
                         errorNoDefault = msg:
                           builtins.throw '' 
-                              A default value for `packages` cannot be auto-detected:
+                              haskell-flake: A default value for `packages` cannot be auto-detected:
 
-                              ${msg}
-
+                                ${msg}
                               You must manually specify the `packages` option.
                             '';
                         cabalPaths =


### PR DESCRIPTION
This, incidentally, allows a _mix_ of top-level and sub-cabal files, but that is okay (we will assume that the user knows what they are doing).

Will further expand the logic in #90 to support `package.yaml`.