### PR TITLE
DRAFT Add `packageSettings`

### DIFF
--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -90,6 +90,7 @@ in
             specialArgs = { inherit pkgs self; };
             modules = [
               ./haskell-project.nix
+              ./package-settings.nix
               {
                 options = {
                   basePackages = mkOption {

--- a/nix/package-settings.nix
+++ b/nix/package-settings.nix
@@ -47,7 +47,7 @@
                       default = null;
                       description = "Whether to run tests";
                     };
-                    doJailbreak = lib.mkOption {
+                    jailbreak = lib.mkOption {
                       type = lib.types.nullOr lib.types.bool;
                       default = null;
                       description = "Whether to disable version bounds";

--- a/nix/package-settings.nix
+++ b/nix/package-settings.nix
@@ -67,6 +67,11 @@
                       default = null;
                       description = "Patches to apply";
                     };
+                    enableSeparateBinOutput = lib.mkOption {
+                      type = lib.types.nullOr lib.types.bool;
+                      default = null;
+                      description = "Whether to enable separate bin output";
+                    };
                   };
                 })
               ];

--- a/nix/package-settings.nix
+++ b/nix/package-settings.nix
@@ -57,6 +57,11 @@
                       default = null;
                       description = "Whether to generate documentation";
                     };
+                    patches = lib.mkOption {
+                      type = lib.types.nullOr (lib.types.listOf lib.types.path);
+                      default = null;
+                      description = "Patches to apply";
+                    };
                   };
                 })
               ];

--- a/nix/package-settings.nix
+++ b/nix/package-settings.nix
@@ -52,6 +52,11 @@
                       default = null;
                       description = "Whether to disable version bounds";
                     };
+                    broken = lib.mkOption {
+                      type = lib.types.nullOr lib.types.bool;
+                      default = null;
+                      description = "Whether the package is broken";
+                    };
                     doHaddock = lib.mkOption {
                       type = lib.types.nullOr lib.types.bool;
                       default = null;

--- a/nix/package-settings.nix
+++ b/nix/package-settings.nix
@@ -1,0 +1,102 @@
+# A haskell-flake module providing a simpler interface to `overrides`. The
+# config implementation simply expands to `overrides`.
+{ config, pkgs, lib, ... }:
+
+{
+  options = {
+    packageSettings = lib.mkOption {
+      type = lib.types.lazyAttrsOf (lib.types.submodule {
+        options = {
+          input = lib.mkOption {
+            default = { };
+            type = lib.types.deferredModuleWith {
+              staticModules = [
+                ({ lib, self, super, ... }: {
+                  # TODO: What is the best way to do enum type here?
+                  options = {
+                    path = lib.mkOption {
+                      type = lib.types.nullOr lib.types.path;
+                      default = null;
+                      description = "Source path";
+                    };
+                    drv = lib.mkOption {
+                      type = lib.types.nullOr lib.types.package;
+                      default = null;
+                      description = "Cabal derivation";
+                    };
+                    hackageVersion = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "Hackage version";
+                    };
+                  };
+                })
+              ];
+            };
+            description = "Source or derivation to use for this package";
+          };
+          overrides = lib.mkOption {
+            default = { };
+            type = lib.types.deferredModuleWith {
+              staticModules = [
+                ({ lib, old, ... }: {
+                  options = {
+                    # TODO: Write the rest of the options
+                    doCheck = lib.mkOption {
+                      type = lib.types.nullOr lib.types.bool;
+                      default = null;
+                      description = "Whether to run tests";
+                    };
+                    doJailbreak = lib.mkOption {
+                      type = lib.types.nullOr lib.types.bool;
+                      default = null;
+                      description = "Whether to disable version bounds";
+                    };
+                    doHaddock = lib.mkOption {
+                      type = lib.types.nullOr lib.types.bool;
+                      default = null;
+                      description = "Whether to generate documentation";
+                    };
+                  };
+                })
+              ];
+            };
+            description = "Cabal overrides";
+          };
+        };
+      });
+      default = { };
+      description = "Package settings";
+    };
+  };
+  config = {
+    overrides = self: super:
+      lib.mapAttrs
+        (name: settings:
+          let
+            evalModSimple = mod: specialArgs:
+              (lib.evalModules { modules = [ mod ]; inherit specialArgs; }).config;
+          in
+          let
+            input = evalModSimple settings.input { inherit lib self super; };
+            drv =
+              # NOTE: See the corresponding TODO on the option type.
+              if input.drv != null
+              then input.drv
+              else if input.hackageVersion != null
+              then self.callHackage name input.hackageVersion { }
+              else if input.path != null
+              then self.callCabal2nix name input.path { }
+              else super.${name};
+            overrideCabal =
+              pkgs.haskell.lib.compose.overrideCabal
+                (old:
+                  let mod = evalModSimple settings.overrides { inherit lib old; };
+                  in lib.filterAttrs (n: v: v != null) mod
+                );
+          in
+          overrideCabal drv
+        )
+        config.packageSettings;
+  };
+}

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -46,6 +46,15 @@
             # docs.
             foo = self.callCabal2nix "foo" (inputs.haskell-multi-nix + /foo) { };
           };
+          # WIP test
+          packageSettings = {
+            bar.input = { self, super, ... }: {
+              # path = inputs.haskell-multi-nix + /foo;
+              # hackageVer = "1.2.3";
+              drv = self.aeson;
+            };
+            foo.overrides = { old, ... }: { doCheck = false; };
+          };
           devShell = {
             tools = hp: {
               # Adding a tool should make it available in devshell.


### PR DESCRIPTION
This is a follow-up to https://github.com/srid/haskell-flake/pull/87#issuecomment-1448903620 (and closes #87 and closes #96).

The module API is slightly diferrent here. While it still uses `deferredModule` (like #96), the `config` implementation of this PR expands directly to `overrides`, thus we can reuse the merge semantics of `overrides` without worrying about writing one for `packageSettings`. We also add `input.hackageVer` as an easier way of doing `self.callHackage ...`.

- [ ] Assess how overlay composition order is affected as a result of this
- [ ] API is slightly clunky owing to what appears to be limitations of the module system (see diff comments)
- [ ] Deprecate/remove `source-overrides` (since the `input` option can do that and more)