### PR TITLE
Make `source-overrides` support Hackage inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - #49 & #91: The `packages` option now autodiscovers the top-level `.cabal` file (in addition to looking inside sub-directories) as its default value.
   - #69: The default flake template creates `flake.nix` only, while the `#example` one creates the full Haskell project template.
   - #92: Add `devShell.mkShellArgs` to pass custom arguments to `mkShell`
+  - ??: `source-overrides` option now supports specifying Hackage versions.
 - API changes
     - #37: Group `buildTools` (renamed to `tools`), `hlsCheck` and `hlintCheck` under the `devShell` submodule option; and allow disabling them all using `devShell.enable = false;` (useful if you want haskell-flake to produce just the package outputs).
     - #64: Remove hlintCheck (use [treefmt-nix](https://github.com/numtide/treefmt-nix#flake-parts) instead)

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -110,8 +110,13 @@ in
                     defaultText = lib.literalExpression "pkgs.haskellPackages";
                   };
                   source-overrides = mkOption {
-                    type = types.attrsOf types.path;
-                    description = ''Package overrides given new source path'';
+                    type = types.attrsOf (types.oneOf [ types.path types.str ]);
+                    description = ''
+                      Source overrides for Haskell packages
+
+                      You can either assign a path to the source, or Hackage
+                      version string.
+                    '';
                     default = { };
                   };
                   overrides = mkOption {


### PR DESCRIPTION
This makes it possible to do:

```nix
{
  source-overrides = {
    foo = inputs.fooRepo + /foo;
    qux = "1.2.3"; # <-- New in this PR
  };
  overrides = self: super: {
    qux = lib.pipe super.qux [ dontCheck dontHaddock ];
  };
}
```

Ref: https://github.com/NixOS/nixpkgs/blame/995edc972ad3a1e291ac22d74b9610821357175f/pkgs/development/haskell-modules/lib/compose.nix#L44-L54