### PR TITLE
Add a default for `haskellFlakeProjectModules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
     - #52: Expose the final package set as `finalPackages`. Rename `haskellPackages`, accordingly, to `basePackages`. Overlays are applied on top of `basePackage` -- using `source-overrides`, `overrides`, `packages` in that order -- to produce `finalPackages`.
     - #68: You can now use `imports` inside of `haskellProjects.<name>` to modularize your Haskell project configuration.
       - #79: `flake.haskellFlakeProjectModules.<name>` option can be used to set and expose your Haskell project modules to other flakes.
-        - #106: Auto-generate the default modules in 'outputs' for reuse in downstream flakes.
+        - #106: Auto-generate the default modules in 'haskellFlakeProjectModules' for reuse in downstream flakes.
       - #67: `overrides` will be combined using `composeManyExtensions`, however their order is arbitrary. This is an experimental feature, and a warning will be logged.
 
 ## 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
     - #52: Expose the final package set as `finalPackages`. Rename `haskellPackages`, accordingly, to `basePackages`. Overlays are applied on top of `basePackage` -- using `source-overrides`, `overrides`, `packages` in that order -- to produce `finalPackages`.
     - #68: You can now use `imports` inside of `haskellProjects.<name>` to modularize your Haskell project configuration.
       - #79: `flake.haskellFlakeProjectModules.<name>` option can be used to set and expose your Haskell project modules to other flakes.
-        - #??: Auto-generate the default modules in 'outputs' for reuse in downstream flakes.
+        - #106: Auto-generate the default modules in 'outputs' for reuse in downstream flakes.
       - #67: `overrides` will be combined using `composeManyExtensions`, however their order is arbitrary. This is an experimental feature, and a warning will be logged.
 
 ## 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - #52: Expose the final package set as `finalPackages`. Rename `haskellPackages`, accordingly, to `basePackages`. Overlays are applied on top of `basePackage` -- using `source-overrides`, `overrides`, `packages` in that order -- to produce `finalPackages`.
     - #68: You can now use `imports` inside of `haskellProjects.<name>` to modularize your Haskell project configuration.
       - #79: `flake.haskellFlakeProjectModules.<name>` option can be used to set and expose your Haskell project modules to other flakes.
+        - #??: Auto-generate the default modules in 'outputs' for reuse in downstream flakes.
       - #67: `overrides` will be combined using `composeManyExtensions`, however their order is arbitrary. This is an experimental feature, and a warning will be logged.
 
 ## 0.1.0

--- a/doc/guide/modules.md
+++ b/doc/guide/modules.md
@@ -52,6 +52,36 @@ A haskell-flake project module takes the following arguments:
 | `pkgs` | The perSystem's `pkgs` argument |
 | `self` | The flake's `self` |
 
+## Default modules
+
+By default, haskell-flake will generate the following modules for the "default" `haskellProject`:
+
+| Module | Contents |
+| -- | -- |
+| `haskellFlakeProjectModules.input` | Dependency overrides only |
+| `haskellFlakeProjectModules.local` | Local packages only |
+| `haskellFlakeProjectModules.output` | Local packages & dependency overrides |
+
+The idea here being that you can "connect" two Haskell projects such that they depend on one another while reusing the overrides from one place. For example, if you have a project "foo" that depends on "bar" and if "foo"'s flake.nix has "bar" as its input, then in "foo"'s `haskellProject.default` entry you can import "bar" as follows:
+
+```nix
+# foo's flake.nix's perSystem
+{ 
+  haskellProjects.default = {
+    imports = [
+      inputs.bar.haskellFlakeProjectModules.output
+    ];
+    packages = {
+      foo.root = ./.;
+    };
+  };
+}
+```
+
+By importing "bar"'s `output` project module, you automatically get the overrides from "bar" (unless you use the `local` module) as well as the local packages[^bar]. This way you don't have to duplicate the `overrides` and manually specify the `source-overrides` in "foo"'s flake.nix.
+
+[^bar]: Local packages come from the `packages` option. So this is typically the "bar" package itself for single-package projects; or all the local projects if it is a multi-package project.
+
 ## Examples
 
 - https://github.com/srid/nixpkgs-140774-workaround

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -3,7 +3,8 @@
 
 let
   inherit (flake-parts-lib)
-    mkPerSystemOption;
+    mkPerSystemOption
+    mkSubmoduleOptions;
   inherit (lib)
     mkOption
     types;
@@ -226,43 +227,7 @@ in
               type = types.attrsOf projectSubmodule;
             };
 
-            haskellFlakeProjectModules = mkOption {
-              type = types.lazyAttrsOf types.deferredModule;
-              description = ''
-                An attrset of `haskellProjects.<name>` modules that can be imported in
-                other flakes.
-              '';
-              defaultText = ''
-                `flake.haskellFlakeProjectModules` modules for this project,
-                for reuse in another flake, when using this project as a
-                Haskell dependency.
 
-                Typically the consumer of this flake will want to use one of the
-                following modules:
-
-                  - output: provides both local package and dependency overrides.
-                  - local: provides only local package overrides (ignores dependency
-                    overrides in this flake)
-              '';
-              default = rec {
-                # The 'output' module provides both local package and dependency
-                # overrides.
-                output = {
-                  imports = [ input local ];
-                };
-                # The 'local' module provides only local package overrides.
-                local = { pkgs, lib, ... }: withSystem pkgs.system ({ config, ... }: {
-                  source-overrides =
-                    lib.mapAttrs (_: v: v.root)
-                      config.haskellProjects.default.packages;
-                });
-                # The 'input' module contains only dependency overrides.
-                input = { pkgs, ... }: withSystem pkgs.system ({ config, ... }: {
-                  inherit (config.haskellProjects.default)
-                    source-overrides overrides;
-                });
-              };
-            };
           };
 
           config =
@@ -301,5 +266,45 @@ in
                   config.haskellProjects;
             };
         });
+
+    flake = mkSubmoduleOptions {
+      haskellFlakeProjectModules = mkOption {
+        type = types.lazyAttrsOf types.deferredModule;
+        description = ''
+          An attrset of `haskellProjects.<name>` modules that can be imported in
+          other flakes.
+        '';
+        defaultText = ''
+          `flake.haskellFlakeProjectModules` modules for this project,
+          for reuse in another flake, when using this project as a
+          Haskell dependency.
+
+          Typically the consumer of this flake will want to use one of the
+          following modules:
+
+            - output: provides both local package and dependency overrides.
+            - local: provides only local package overrides (ignores dependency
+              overrides in this flake)
+        '';
+        default = rec {
+          # The 'output' module provides both local package and dependency
+          # overrides.
+          output = {
+            imports = [ input local ];
+          };
+          # The 'local' module provides only local package overrides.
+          local = { pkgs, lib, ... }: withSystem pkgs.system ({ config, ... }: {
+            source-overrides =
+              lib.mapAttrs (_: v: v.root)
+                config.haskellProjects.default.packages;
+          });
+          # The 'input' module contains only dependency overrides.
+          input = { pkgs, ... }: withSystem pkgs.system ({ config, ... }: {
+            inherit (config.haskellProjects.default)
+              source-overrides overrides;
+          });
+        };
+      };
+    };
   };
 }

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -227,7 +227,6 @@ in
               type = types.attrsOf projectSubmodule;
             };
 
-
           };
 
           config =

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -274,9 +274,8 @@ in
           other flakes.
         '';
         defaultText = ''
-          `flake.haskellFlakeProjectModules` modules for this project,
-          for reuse in another flake, when using this project as a
-          Haskell dependency.
+          Package and dependency information for this project exposed for reuse
+          in another flake, when using this project as a Haskell dependency.
 
           Typically the consumer of this flake will want to use one of the
           following modules:

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -126,6 +126,22 @@ in
                   The `hlsCheck` derivation generated for this project.
                 '';
               };
+              projectModules = mkOption {
+                type = types.lazyAttrsOf types.deferredModule;
+                readOnly = true;
+                description = ''
+                  `flake.haskellFlakeProjectModules` modules for this project,
+                  for reuse in another flake, when using this project as a
+                  Haskell dependency.
+
+                  Typically the consumer of this flake will want to use one of the
+                  following modules:
+
+                    - output: provides both local package and dependency overrides.
+                    - local: provides only local package overrides (ignores dependency
+                      overrides in this flake)
+                '';
+              };
             };
           };
           projectSubmodule = types.submoduleWith {

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -1,5 +1,5 @@
 # Definition of the `haskellProjects.${name}` submodule's `config`
-{ name, self, config, lib, pkgs, withSystem, ... }:
+{ name, self, config, lib, pkgs, ... }:
 let
   # Like pkgs.runCommand but runs inside nix-shell with a mutable project directory.
   #
@@ -110,7 +110,6 @@ in
           devShell
           self "${projectKey}-hls-check"
           { } "haskell-language-server";
-
 
       };
     };

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -111,24 +111,7 @@ in
           self "${projectKey}-hls-check"
           { } "haskell-language-server";
 
-        projectModules = rec {
-          # The 'output' module provides both local package and dependency
-          # overrides.
-          output = {
-            imports = [ input local ];
-          };
-          # The 'local' module provides only local package overrides.
-          local = { pkgs, lib, ... }: withSystem pkgs.system ({ config, ... }: {
-            source-overrides =
-              lib.mapAttrs (_: v: v.root)
-                config.haskellProjects.default.packages;
-          });
-          # The 'input' module contains only dependency overrides.
-          input = { pkgs, ... }: withSystem pkgs.system ({ config, ... }: {
-            inherit (config.haskellProjects.default)
-              source-overrides overrides;
-          });
-        };
+
       };
     };
 }

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -1,5 +1,5 @@
 # Definition of the `haskellProjects.${name}` submodule's `config`
-{ name, self, config, lib, pkgs, ... }:
+{ name, self, config, lib, pkgs, withSystem, ... }:
 let
   # Like pkgs.runCommand but runs inside nix-shell with a mutable project directory.
   #
@@ -111,6 +111,24 @@ in
           self "${projectKey}-hls-check"
           { } "haskell-language-server";
 
+        projectModules = rec {
+          # The 'output' module provides both local package and dependency
+          # overrides.
+          output = {
+            imports = [ input local ];
+          };
+          # The 'local' module provides only local package overrides.
+          local = { pkgs, lib, ... }: withSystem pkgs.system ({ config, ... }: {
+            source-overrides =
+              lib.mapAttrs (_: v: v.root)
+                config.haskellProjects.default.packages;
+          });
+          # The 'input' module contains only dependency overrides.
+          input = { pkgs, ... }: withSystem pkgs.system ({ config, ... }: {
+            inherit (config.haskellProjects.default)
+              source-overrides overrides;
+          });
+        };
       };
     };
 }


### PR DESCRIPTION
Resolves #84 

The idea here is to expose the local packages and overrides for reuse in downstream flake. Could well build a network of haskell flakes this way. 

- [x] Prototype
- [x] Documentation

