### PR TITLE
Add `devShell.extraLibraries` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - #49 & #91: The `packages` option now autodiscovers the top-level `.cabal` file (in addition to looking inside sub-directories) as its default value.
   - #69: The default flake template creates `flake.nix` only, while the `#example` one creates the full Haskell project template.
   - #92: Add `devShell.mkShellArgs` to pass custom arguments to `mkShell`
+  - #111: Add `devShell.extraLibraries` to add custom Haskell libraries to the devshell.
   - #100: `source-overrides` option now supports specifying Hackage versions.
 - API changes
     - #37: Group `buildTools` (renamed to `tools`), `hlsCheck` and `hlintCheck` under the `devShell` submodule option; and allow disabling them all using `devShell.enable = false;` (useful if you want haskell-flake to produce just the package outputs).

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -63,6 +63,20 @@ in
                   Build tools useful for Haskell development are included by default.
                 '';
               };
+              extraLibraries = mkOption {
+                type = functionTo (types.attrsOf (types.nullOr types.package));
+                description = ''
+                  Extra Haskell libraries available in the shell's environment.
+                  These can be used in the shell's `runghc` and `ghci` for instance.
+
+                  The argument is the Haskell package set.
+
+                  The return type is an attribute set for overridability and syntax, as only the values are used.
+                '';
+                default = hp: { };
+                defaultText = lib.literalExpression "hp: { }";
+                example = lib.literalExpression "hp: { inherit (hp) releaser; }";
+              };
               hlsCheck = mkOption {
                 default = { };
                 type = hlsCheckSubmodule;

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -83,6 +83,12 @@ in
             (name: p."${name}")
             (lib.attrNames config.packages);
         withHoogle = true;
+        extraDependencies = p:
+          let o = mkShellArgs.extraDependencies or (_: { }) p;
+          in o // {
+            libraryHaskellDepends = o.libraryHaskellDepends or []
+              ++ builtins.attrValues (config.devShell.extraLibraries p);
+          };
       });
     in
     {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -51,6 +51,9 @@
               # Adding a tool should make it available in devshell.
               fzf = pkgs.fzf;
             };
+            extraLibraries = hp: {
+              inherit (hp) tomland;
+            };
             mkShellArgs.shellHook = ''
               echo "Hello from devshell!"
               export FOO=bar

--- a/test/script
+++ b/test/script
@@ -1,0 +1,5 @@
+import Toml.Type.Value (Value(Bool))
+
+main :: IO ()
+main = do
+  putStrLn ("I depend on the `tomland` package. Here's a TOML-flavored boolean: " <> show (Bool True))

--- a/test/test.sh
+++ b/test/test.sh
@@ -24,3 +24,6 @@ else
     echo "FOO is not bar" 
     exit 2
 fi
+
+# extraLibraries works
+runghc ./script | grep -F 'TOML-flavored boolean: Bool True'


### PR DESCRIPTION
> Extra Haskell libraries available in the shell's environment.

I'm already using a worse implementation of this in hercules-ci-agent to make as `runghc` shebang script work: https://github.com/hercules-ci/hercules-ci-agent/commit/6da8c81312b36e81e0f674780585571998c47d51 (quickly hacked together at release time...)

This is an improved version of that with
 - a test
 - no clobbering of the `extraDependencies` parameter

I've also validated it locally with hercules-ci-agent.
