### PR TITLE
fix: include withSystem as specialArgs

### DIFF
--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -311,6 +311,7 @@ in
 
     flake = mkOption {
       type = types.submoduleWith {
+        specialArgs = { inherit withSystem; };
         modules = [
           ./default-project-modules.nix
           {


### PR DESCRIPTION
closes #118 
default-project-modules.nix expects withSystem as input but fails with attribute missing and hence has to be explicitly inherited in specialArgs