### PR TITLE
Add Jenkins CI (secondary CI)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage ('Tests') {
+            steps {
+                sh 'nix run nixpkgs#bash runtest.sh'
+            }
+        }
+    }
+}


### PR DESCRIPTION
We'll continue to use Github Actions as the primary CI, as Jenkins logs are not publicly exposed. 

Main benefits Jenkins provides is the faster CI feedback; and eventually, M1 macOS support. I'm also exploring Jenkins lately for Nix builds, so this PR is also part of dogfooding my setup https://github.com/srid/nixos-config/pull/34 in a few projects.

