### PR TITLE
Add `outputs.checks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `master`
 
 - #134: Add `autoWire` option to control generation of flake outputs
+    - ??: Add `checks` to `outputs` submodule
 
 ## 0.2.0 (Mar 13, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## `master`
 
 - #134: Add `autoWire` option to control generation of flake outputs
-    - ??: Add `checks` to `outputs` submodule
+    - #138: Add `checks` to `outputs` submodule
 
 ## 0.2.0 (Mar 13, 2023)
 

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -32,7 +32,13 @@ in
                 '';
                 default = false;
               };
-
+              drv = mkOption {
+                type = types.package;
+                readOnly = true;
+                description = ''
+                  The `hlsCheck` derivation generated for this project.
+                '';
+              };
             };
           };
           packageSubmodule = with types; submodule {
@@ -136,13 +142,14 @@ in
                   The development shell derivation generated for this project.
                 '';
               };
-              hlsCheck = mkOption {
-                type = types.package;
+              checks = mkOption {
+                type = types.lazyAttrsOf types.package;
                 readOnly = true;
                 description = ''
-                  The `hlsCheck` derivation generated for this project.
+                  The flake checks generated for this project.
                 '';
               };
+
             };
           };
           projectSubmodule = types.submoduleWith {
@@ -310,9 +317,8 @@ in
               checks =
                 mergeMapAttrs
                   (name: project:
-                    lib.optionalAttrs (project.autoWire && project.devShell.enable && project.devShell.hlsCheck.enable) {
-                      "${name}-hls" = project.outputs.hlsCheck;
-                    })
+                    project.outputs.checks
+                  )
                   config.haskellProjects;
             };
         });

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -317,7 +317,7 @@ in
               checks =
                 mergeMapAttrs
                   (name: project:
-                    project.outputs.checks
+                    lib.optionalAttrs project.autoWire project.outputs.checks
                   )
                   config.haskellProjects;
             };

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -62,6 +62,11 @@ in
               ++ builtins.attrValues (config.devShell.extraLibraries p);
           };
       });
+      hlsCheck =
+        runCommandInSimulatedShell
+          devShell
+          self "${projectKey}-hls-check"
+          { } "haskell-language-server";
     in
     {
       outputs = {
@@ -84,11 +89,12 @@ in
           (name: _: finalPackages."${name}")
           config.packages;
 
-        hlsCheck = runCommandInSimulatedShell
-          devShell
-          self "${projectKey}-hls-check"
-          { } "haskell-language-server";
+        checks = lib.filterAttrs (_: v: v != null) {
+          "${name}-hls" = if (config.devShell.enable && config.devShell.hlsCheck.enable) then hlsCheck else null;
+        };
 
       };
+
+      devShell.hlsCheck.drv = hlsCheck;
     };
 }


### PR DESCRIPTION
When the user has `autoWire = false;`, there is currently no way to get the `checks`. This PR fixes that.

Used in https://github.com/srid/haskell-template/pull/99