### PR TITLE
Use `enableSeparateBinOutput` to prevent duplicate builds

### DIFF
--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -61,4 +61,9 @@ lib.pipe pkg
     # Make sure all files we use are included in the sdist, as a check
     # for release-worthiness.
     fromSdist
+
+    # TODO: Make it an option that the user can override
+    # This is better than using justStaticExecutables, because with the later
+    # builds will repeated twice!
+    pkgs.haskell.lib.enableSeparateBinOutput
   ]

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -68,16 +68,13 @@ in
         package = finalPackages.${name};
         exes =
           let
-            inherit (pkgs.haskell.lib) enableSeparateBinOutput;
             exeNames = haskell-parsers.getCabalExecutables value.root;
-            # TODO: We must do this globally in overlay, to avoid repeat builds?
-            packageBinOut = (enableSeparateBinOutput finalPackages.${name}).bin;
           in
           lib.listToAttrs
             (map
               (exe:
                 lib.nameValuePair exe {
-                  program = "${packageBinOut}/bin/${exe}";
+                  program = "${lib.getBin finalPackages.${name}}/bin/${exe}";
                 }
               )
               exeNames

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -68,14 +68,16 @@ in
         package = finalPackages.${name};
         exes =
           let
+            inherit (pkgs.haskell.lib) enableSeparateBinOutput;
             exeNames = haskell-parsers.getCabalExecutables value.root;
-            staticPackage = pkgs.haskell.lib.justStaticExecutables finalPackages.${name};
+            # TODO: We must do this globally in overlay, to avoid repeat builds?
+            packageBinOut = (enableSeparateBinOutput finalPackages.${name}).bin;
           in
           lib.listToAttrs
             (map
               (exe:
                 lib.nameValuePair exe {
-                  program = "${staticPackage}/bin/${exe}";
+                  program = "${packageBinOut}/bin/${exe}";
                 }
               )
               exeNames


### PR DESCRIPTION
Aims to resolve https://github.com/nammayatri/nammayatri/issues/687

Basically, the use of `justStaticExecutables` causes the library/executable to be built **twice**!

---

Normal library build:

```
❯ nix build github:srid/devour-flake --no-link --print-out-paths --override-input flake github:srid/haskell-template/bdd135025466fc82fbc88a46043c53ec28930979 2> /dev/null | xargs cat | tr ' ' '\n' | grep -E "\-haskell-template-0.1.0.0$" | uniq
/nix/store/kv6yrjqs08nxirqvwjbi7lm763lbizcz-haskell-template-0.1.0.0
```

With [`justStaticExecutables`](https://github.com/srid/haskell-template/commit/0bbc2493d0891cb57cc2a926466bfb562557019c),

```
❯ nix build github:srid/devour-flake --no-link --print-out-paths --override-input flake github:srid/haskell-template/0bbc2493d0891cb57cc2a926466bfb562557019c 2> /dev/null | xargs cat | tr ' ' '\n' | grep -E "\-haskell-template-0.1.0.0$" | uniq
/nix/store/ra02zpjymb3fyjsbaln661k13ayrnyws-haskell-template-0.1.0.0
/nix/store/di3798v15v4q6db10c6sx87664gxrfzp-haskell-template-0.1.0.0
```

---

The solution here seems to be to use `enableSeparateBinOutput`. This PR in the current form enables this flag for **all** packages. Not sure if that's desirable; so we may want to have an option to turn it off (`packages.<name>.flags.separateBinOutput`?).