### PR TITLE
Run `cleanSourceWith` *before* `cabal2nix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - #143: Changed `autoWire` to be an enum type, for granular controlling of which outputs to autowire.
 - #137: Expose cabal executables as flake apps. Add a corresponding `outputs.apps` option, while the `outputs.localPackages` option is renamed to `outputs.packages` (it now contains package metadata, including packages and its executables).
 - #148: Remove automatic hpack->cabal generation. Use `pre-commit-hooks.nix` instead.
+- #149: Fix unnecessary re-runs of cabal2nix evaluation. Add a `debug` option to enable produce verbose diagnostic messages.
 
 ## 0.2.0 (Mar 13, 2023)
 

--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -1,9 +1,11 @@
 # Like callCabal2nix, but does more:
 # - Source filtering (to prevent parent content changes causing rebuilds)
 # - Always build from cabal's sdist for release-worthiness
-{ pkgs, lib, self, ... }:
+{ pkgs, lib, self, debug, ... }:
 
 let
+  log = import ./logging.nix { inherit lib debug; };
+
   fromSdist = self.buildFromCabalSdist or (builtins.trace "Your version of Nixpkgs does not support hs.buildFromCabalSdist yet." (pkg: pkg));
 
   mkNewStorePath = name: src:
@@ -23,12 +25,13 @@ lib.pipe pkgCfg.root
   [
     # Avoid rebuilding because of changes in parent directories
     (mkNewStorePath "source-${name}")
-
-    (x: builtins.trace x.outPath x)
+    (log.traceDebug "${name}.mkNewStorePath" (x: x.outPath))
 
     (root: self.callCabal2nix name root { })
+    (log.traceDebug "${name}.cabal2nixDeriver" (x: x.cabal2nixDeriver.outPath))
 
     # Make sure all files we use are included in the sdist, as a check
     # for release-worthiness.
     fromSdist
+    (log.traceDebug "${name}.fromSdist" (x: x.outPath))
   ]

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -201,6 +201,15 @@ in
                     default = self;
                     defaultText = "Top-level directory of the flake";
                   };
+                  debug = mkOption {
+                    type = types.bool;
+                    default = false;
+                    description = ''
+                      Whether to enable verbose trace output from haskell-flake.
+
+                      Useful for debugging.
+                    '';
+                  };
                   basePackages = mkOption {
                     type = types.attrsOf raw;
                     description = ''

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -35,7 +35,10 @@ in
 
       localPackagesOverlay = self: _:
         let
-          build-haskell-package = import ./build-haskell-package.nix { inherit pkgs lib self; };
+          build-haskell-package = import ./build-haskell-package.nix {
+            inherit pkgs lib self;
+            inherit (config) debug;
+          };
         in
         lib.mapAttrs build-haskell-package config.packages;
 

--- a/nix/logging.nix
+++ b/nix/logging.nix
@@ -1,0 +1,11 @@
+{ lib, debug, ... }:
+
+{
+  traceDebug = k: f:
+    if debug then
+      (x: lib.pipe x [
+        (builtins.trace ("DEBUG[haskell-flake]: " + k + " " + f x))
+      ])
+    else
+      (x: x);
+}


### PR DESCRIPTION
Also make haskell-flake produce more debug output (if `debug` is enabled by the user)