### PR TITLE
exe: Use `getBin` instead of `justStaticExecutables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - #138: Add `checks` to `outputs` submodule
     - #143: Changed `autoWire` to be an enum type, for granular controlling of which outputs to autowire.
 - #137: Expose cabal executables as flake apps. Add a corresponding `outputs.apps` option, while the `outputs.localPackages` option is renamed to `outputs.packages` (it now contains package metadata, including packages and its executables).
+  - #151: Use `lib.getBin` to get the bin output
 - #148: Remove automatic hpack->cabal generation. Use `pre-commit-hooks.nix` instead.
 - #149: Fix unnecessary re-runs of cabal2nix evaluation. Add a `debug` option to have haskell-flake produce diagnostic messages.
 

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -176,8 +176,9 @@ in
                 description = ''
                   Attrset of executables from `.cabal` file.  
 
-                  The executables are accessed without any reference to the
-                  Haskell library, using `justStaticExecutables`.
+                  If the associated Haskell project has a separate bin output
+                  (cf. `enableSeparateBinOutput`), then this exes will refer
+                  only to the bin output.
 
                   NOTE: Evaluating up to this option will involve IFD.
                 '';

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -72,13 +72,12 @@ in
         exes =
           let
             exeNames = haskell-parsers.getCabalExecutables value.root;
-            staticPackage = pkgs.haskell.lib.justStaticExecutables finalPackages.${name};
           in
           lib.listToAttrs
             (map
               (exe:
                 lib.nameValuePair exe {
-                  program = "${staticPackage}/bin/${exe}";
+                  program = "${lib.getBin finalPackages.${name}}/bin/${exe}";
                 }
               )
               exeNames


### PR DESCRIPTION
`justStaticExecutables` is problematic because it can produce double builds (see #146), so just use `getBin` which is especially useful if the user does `enableSeparateBinOutputs` on the user sude.