### PR TITLE
Add `defaults` submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - #151: Use `lib.getBin` to get the bin output
 - #148: Remove automatic hpack->cabal generation. Use `pre-commit-hooks.nix` instead.
 - #149: Fix unnecessary re-runs of cabal2nix evaluation. Add a `debug` option to have haskell-flake produce diagnostic messages.
+- #153: Add `config.defaults` submodule to allow overriding the default devShell tools added by haskell-flake
 
 ## 0.2.0 (Mar 13, 2023)
 

--- a/nix/modules/project.nix
+++ b/nix/modules/project.nix
@@ -84,6 +84,7 @@ in
 {
   imports = [
     ./project/devshell.nix
+    ./project/defaults.nix
   ];
   options = {
     projectRoot = mkOption {

--- a/nix/modules/project/defaults.nix
+++ b/nix/modules/project/defaults.nix
@@ -1,0 +1,24 @@
+# A module representing the default values used internally by haskell-flake.
+{ lib, ... }:
+let
+  inherit (lib)
+    mkOption
+    types;
+  inherit (types)
+    functionTo;
+in
+{
+  options.defaults = {
+    devShell.tools = mkOption {
+      type = functionTo (types.attrsOf (types.nullOr types.package));
+      description = ''Build tools always included in devShell'';
+      default = hp: with hp; {
+        inherit
+          cabal-install
+          haskell-language-server
+          ghcid
+          hlint;
+      };
+    };
+  };
+}

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -20,11 +20,12 @@ let
         type = functionTo (types.attrsOf (types.nullOr types.package));
         description = ''
           Build tools for developing the Haskell project.
+
+          These tools are merged with the haskell-flake defaults defined in the
+          `defaults.devShell.tools` option. Set the value to `null` to remove
+          that default tool.
         '';
         default = hp: { };
-        defaultText = ''
-          Build tools useful for Haskell development are included by default.
-        '';
       };
       extraLibraries = mkOption {
         type = functionTo (types.attrsOf (types.nullOr types.package));
@@ -83,14 +84,10 @@ in
     let
       inherit (config.outputs) finalPackages;
 
-      defaultBuildTools = hp: with hp; {
-        inherit
-          cabal-install
-          haskell-language-server
-          ghcid
-          hlint;
-      };
-      nativeBuildInputs = lib.attrValues (defaultBuildTools finalPackages // config.devShell.tools finalPackages);
+      nativeBuildInputs = lib.attrValues (
+        config.defaults.devShell.tools finalPackages //
+        config.devShell.tools finalPackages
+      );
       mkShellArgs = config.devShell.mkShellArgs // {
         nativeBuildInputs = (config.devShell.mkShellArgs.nativeBuildInputs or [ ]) ++ nativeBuildInputs;
       };


### PR DESCRIPTION
See the last point in https://github.com/srid/haskell-flake/issues/101#issuecomment-1528006895 for context

This PR enables users to change the hardcoded value here:

https://github.com/srid/haskell-flake/blob/fb1a3c32a8efd1c7bb4a9fe1f68a42e0114dd533/nix/modules/project/devshell.nix#L86-L92

And then use it (via project `imports`) in multiple projects.

We could as well add a default option for override `settings` (#101) to solve #146 in a better way.