### PR TITLE
`benchmark` and `hoogle` option in devShellSubmodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Add `project.config.defaults.settings.default` defining sensible defaults for local packages.
   - Add `project.config.defaults.enable` to turn off all default settings en masse.
   - Regressions in this PR: #169
+- #175: `devShell`: Add options `benchmark` (to enable benchmark dependencies) and `hoogle` (whether to include Hoogle in development shell)
 
 ## 0.3.0 (May 22, 2023)
 

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -70,6 +70,7 @@ let
 
       hoogle = mkOption {
         type = types.bool;
+        default = true;
         description = ''
           Whether to include Hoogle in the development shell.
           The value of this option will set the corresponding `withHoogle` flag in the
@@ -119,7 +120,7 @@ in
             (name: p."${name}")
             (lib.attrNames localPackages);
         withHoogle = config.devShell.hoogle;
-        doBenchmark = config.devShell.includeBenchmarkDeps;
+        doBenchmark = config.devShell.benchmark;
         extraDependencies = p:
           let o = mkShellArgs.extraDependencies or (_: { }) p;
           in o // {

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -58,13 +58,23 @@ let
         '';
       };
 
-      includeBenchmarkDeps = mkOption {
+      benchmark = mkOption {
         type = types.bool;
         description = ''
           Whether to include benchmark dependencies in the development shell.
-          You should set this to `true` if you have a `benchmark` defined in your package's cabal file.
+          The value of this option will set the corresponding `doBenchmark` flag in the
+          `shellFor` derivation.
         '';
         default = false;
+      };
+
+      hoogle = mkOption {
+        type = types.bool;
+        description = ''
+          Whether to include Hoogle in the development shell.
+          The value of this option will set the corresponding `withHoogle` flag in the
+          `shellFor` derivation.
+        '';
       };
     };
   };
@@ -108,7 +118,7 @@ in
           map
             (name: p."${name}")
             (lib.attrNames localPackages);
-        withHoogle = true;
+        withHoogle = config.devShell.hoogle;
         doBenchmark = config.devShell.includeBenchmarkDeps;
         extraDependencies = p:
           let o = mkShellArgs.extraDependencies or (_: { }) p;

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -57,6 +57,15 @@ let
           };
         '';
       };
+
+      includeBenchmarkDeps = mkOption {
+        type = types.bool;
+        description = ''
+          Whether to include benchmark dependencies in the development shell.
+          You should set this to `true` if you have a `benchmark` defined in your package's cabal file.
+        '';
+        default = false;
+      };
     };
   };
 in
@@ -100,6 +109,7 @@ in
             (name: p."${name}")
             (lib.attrNames localPackages);
         withHoogle = true;
+        doBenchmark = config.devShell.includeBenchmarkDeps;
         extraDependencies = p:
           let o = mkShellArgs.extraDependencies or (_: { }) p;
           in o // {


### PR DESCRIPTION
The `shellFor` function allows specifying the `doBenchmark` attribute to include the benchmark's `build-depends` from the `.cabal` file in the derivation. We have to expose this option as an attribute in the `devShellSubmodule` of haskell-flake.
 
As a hack this attribute input can still be passed to `shellFor` like, `devShell.mkShellArgs.doBenchmark = true;` but that's not the intended behaviour of `mkShellArgs` option.

In addition to the above change, this PR also makes `withHoogle` input to `shellFor` also a configurable option under `devShellSubmodule`.