### PR TITLE
`devShell.extraLibraries`: abort when using an older commit of nixpkgs

### DIFF
--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -28,7 +28,7 @@ let
         default = hp: { };
       };
       extraLibraries = mkOption {
-        type = functionTo (types.attrsOf (types.nullOr types.package));
+        type = types.nullOr (functionTo (types.attrsOf (types.nullOr types.package)));
         description = ''
           Extra Haskell libraries available in the shell's environment.
           These can be used in the shell's `runghc` and `ghci` for instance.
@@ -37,7 +37,9 @@ let
 
           The return type is an attribute set for overridability and syntax, as only the values are used.
         '';
-        default = hp: { };
+        default = null;
+        apply = f: hp:
+          if f == null then { } else f hp;
         defaultText = lib.literalExpression "hp: { }";
         example = lib.literalExpression "hp: { inherit (hp) releaser; }";
       };
@@ -130,7 +132,10 @@ in
                 ++ builtins.attrValues (config.devShell.extraLibraries p);
             }
           else
-            config.log.traceWarning "Your nixpkgs does not support `extraDependencies` in `shellFor`." null;
+            if config.devShell.extraLibraries != null then
+              builtins.throw "The 'extraLibraries' option is only available when using a version of nixpkgs that supports extraDependencies in shellFor."
+            else
+              null;
       });
 
     in

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -40,7 +40,7 @@ let
         default = null;
         apply = f: hp:
           if f == null then { } else f hp;
-        defaultText = lib.literalExpression "hp: { }";
+        defaultText = lib.literalExpression "null";
         example = lib.literalExpression "hp: { inherit (hp) releaser; }";
       };
 

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -124,11 +124,11 @@ in
         extraDependencies =
           if lib.hasAttr "extraDependencies" (lib.functionArgs finalPackages.shellFor) then
             p:
-              let o = mkShellArgs.extraDependencies or (_: { }) p;
-              in o // {
-                libraryHaskellDepends = o.libraryHaskellDepends or [ ]
-                  ++ builtins.attrValues (config.devShell.extraLibraries p);
-              }
+            let o = mkShellArgs.extraDependencies or (_: { }) p;
+            in o // {
+              libraryHaskellDepends = o.libraryHaskellDepends or [ ]
+                ++ builtins.attrValues (config.devShell.extraLibraries p);
+            }
           else
             config.log.traceWarning "Your nixpkgs does not support `extraDependencies` in `shellFor`." null;
       });

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -121,12 +121,16 @@ in
             (lib.attrNames localPackages);
         withHoogle = config.devShell.hoogle;
         doBenchmark = config.devShell.benchmark;
-        extraDependencies = p:
-          let o = mkShellArgs.extraDependencies or (_: { }) p;
-          in o // {
-            libraryHaskellDepends = o.libraryHaskellDepends or [ ]
-              ++ builtins.attrValues (config.devShell.extraLibraries p);
-          };
+        extraDependencies =
+          if lib.hasAttr "extraDependencies" (lib.functionArgs finalPackages.shellFor) then
+            p:
+              let o = mkShellArgs.extraDependencies or (_: { }) p;
+              in o // {
+                libraryHaskellDepends = o.libraryHaskellDepends or [ ]
+                  ++ builtins.attrValues (config.devShell.extraLibraries p);
+              }
+          else
+            config.log.traceWarning "Your nixpkgs does not support `extraDependencies` in `shellFor`." null;
       });
 
     in

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -38,8 +38,6 @@ let
           The return type is an attribute set for overridability and syntax, as only the values are used.
         '';
         default = null;
-        apply = f: hp:
-          if f == null then { } else f hp;
         defaultText = lib.literalExpression "null";
         example = lib.literalExpression "hp: { inherit (hp) releaser; }";
       };
@@ -123,16 +121,16 @@ in
             (lib.attrNames localPackages);
         withHoogle = config.devShell.hoogle;
         doBenchmark = config.devShell.benchmark;
-        extraDependencies =
+        extraDependencies = let hasExtraLibraries = config.devShell.extraLibraries != null; in
           if lib.hasAttr "extraDependencies" (lib.functionArgs finalPackages.shellFor) then
             p:
             let o = mkShellArgs.extraDependencies or (_: { }) p;
             in o // {
               libraryHaskellDepends = o.libraryHaskellDepends or [ ]
-                ++ builtins.attrValues (config.devShell.extraLibraries p);
+                ++ builtins.attrValues (if hasExtraLibraries then config.devShell.extraLibraries p else { });
             }
           else
-            if config.devShell.extraLibraries != null then
+            if hasExtraLibraries then
               builtins.throw "The 'extraLibraries' option is only available when using a version of nixpkgs that supports extraDependencies in shellFor."
             else
               null;


### PR DESCRIPTION
`extraDependencies` was added as an argument to `shellFor` only after: https://github.com/NixOS/nixpkgs/commit/2e87d165f74411ae00f964a508945696969ff53d