### PR TITLE
Switch to `buildFromSdist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - #215: Improved debug logging.
 - #216: Remove `debug` option (pass `--trace-verbose` to nix instead)
 - Breaking changes
-  - #221: Switch to `buildFromSdist`, to allow using non-standard package sets (wherein `cabal-install` is built without using user's overrides)
+  - #221: Switch to `buildFromSdist`, to allow using non-standard package sets (wherein `cabal-install` is otherwise built without using user's overrides)
 
 ## 0.4.0 (Aug 22, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - #210: Add `extraLibraries` to `settings` module.
 - #215: Improved debug logging.
 - #216: Remove `debug` option (pass `--trace-verbose` to nix instead)
+- Breaking changes
+  - #221: Switch to `buildFromSdist`, to allow using non-standard package sets (wherein `cabal-install` is built without using user's overrides)
 
 ## 0.4.0 (Aug 22, 2023)
 

--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -14,7 +14,7 @@
 let
   # NOTE: We do not use the optimized version, `buildFromCabalSdist`, because it
   # breaks in some cases. See https://github.com/srid/haskell-flake/pull/220
-  fromSdist = self.buildFromSdist or
+  fromSdist = pkgs.lib.haskell.buildFromSdist or
     (log.traceWarning "Your nixpkgs does not have hs.buildFromSdist" (pkg: pkg));
 
   mkNewStorePath = name: src:

--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -14,7 +14,7 @@
 let
   # NOTE: We do not use the optimized version, `buildFromCabalSdist`, because it
   # breaks in some cases. See https://github.com/srid/haskell-flake/pull/220
-  fromSdist = pkgs.lib.haskell.buildFromSdist or
+  fromSdist = pkgs.haskell.lib.buildFromSdist or
     (log.traceWarning "Your nixpkgs does not have hs.buildFromSdist" (pkg: pkg));
 
   mkNewStorePath = name: src:

--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -12,8 +12,10 @@
 }:
 
 let
-  fromSdist = self.buildFromCabalSdist or
-    (log.traceWarning "Your nixpkgs does not have hs.buildFromCabalSdist" (pkg: pkg));
+  # NOTE: We do not use the optimized version, `buildFromCabalSdist`, because it
+  # breaks in some cases. See https://github.com/srid/haskell-flake/pull/220
+  fromSdist = self.buildFromSdist or
+    (log.traceWarning "Your nixpkgs does not have hs.buildFromSdist" (pkg: pkg));
 
   mkNewStorePath = name: src:
     # Since 'src' may be a subdirectory of a store path


### PR DESCRIPTION
Closes #220 

`buildFromCabalSdist` has problems; see #220 

So we are switching to the slightly less performant `buildFromSdist`.