### PR TITLE
Make `devShell.tools` a lazyAttrsOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - #210: Add `extraLibraries` to `settings` module.
 - #215: Improved debug logging.
 - #216: Remove `debug` option (pass `--trace-verbose` to nix instead)
-- #222: Improve `cabal.project` parser by handling files not ending with newline
+- Fixes
+  - #222: Improve `cabal.project` parser by handling files not ending with newline
+  - #223 Make `devShell.tools` a `lazyAttrsOf` (lazy evaluation of values)
 - Breaking changes
   - #221: Switch to `buildFromSdist`, to allow using non-standard package sets (wherein `cabal-install` is otherwise built without using user's overrides)
 

--- a/nix/modules/project/defaults.nix
+++ b/nix/modules/project/defaults.nix
@@ -18,7 +18,7 @@ in
     };
 
     devShell.tools = mkOption {
-      type = functionTo (types.attrsOf (types.nullOr types.package));
+      type = functionTo (types.lazyAttrsOf (types.nullOr types.package));
       description = ''Build tools always included in devShell'';
       default = hp: with hp; lib.optionalAttrs config.defaults.enable {
         inherit

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -17,7 +17,7 @@ let
         default = true;
       };
       tools = mkOption {
-        type = functionTo (types.attrsOf (types.nullOr types.package));
+        type = functionTo (types.lazyAttrsOf (types.nullOr types.package));
         description = ''
           Build tools for developing the Haskell project.
 


### PR DESCRIPTION
Otherwise, eager evaluation will always evaluate the defaults.