### PR TITLE
dev: treefmt: specify projectRoot from flake input

### DIFF
--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -5,6 +5,7 @@
     flake-root.url = "github:srid/flake-root";
     mission-control.url = "github:Platonic-Systems/mission-control";
     treefmt-nix.url = "github:numtide/treefmt-nix";
+    haskell-flake = {};
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -16,7 +17,7 @@
       ];
       perSystem = { pkgs, lib, config, ... }: {
         treefmt.config = {
-          projectRoot = ../.;
+          projectRoot = inputs.haskell-flake;
           projectRootFile = "README.md";
           programs.nixpkgs-fmt.enable = true;
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
     # https://github.com/srid/nixci
     nixci.default = let overrideInputs = { "haskell-flake" = ./.; }; in {
-      dev.dir = "dev";
+      dev = { inherit overrideInputs; dir = "dev"; };
       doc.dir = "doc";
       example = { inherit overrideInputs; dir = "example"; };
     };


### PR DESCRIPTION
`../.` cannot be accessed in impure mode.