### PR TITLE
Apply `buildFromSdist` *after* settings overlay

### DIFF
--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -1,6 +1,5 @@
-# Like callCabal2nix, but does more:
+# Wrapped around callCabal2nix, that does:
 # - Source filtering (to prevent parent content changes causing rebuilds)
-# - Always build from cabal's sdist for release-worthiness
 # - Logs what it's doing (based on 'log' option)
 #
 { pkgs

--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -12,11 +12,6 @@
 }:
 
 let
-  # NOTE: We do not use the optimized version, `buildFromCabalSdist`, because it
-  # breaks in some cases. See https://github.com/srid/haskell-flake/pull/220
-  fromSdist = pkgs.haskell.lib.buildFromSdist or
-    (log.traceWarning "Your nixpkgs does not have hs.buildFromSdist" (pkg: pkg));
-
   mkNewStorePath = name: src:
     # Since 'src' may be a subdirectory of a store path
     # (in string form, which means that it isn't automatically
@@ -38,9 +33,4 @@ lib.pipe root
 
     (root: self.callCabal2nix name root { })
     (x: log.traceDebug "${name}.cabal2nixDeriver ${x.cabal2nixDeriver.outPath}" x)
-
-    # Make sure all files we use are included in the sdist, as a check
-    # for release-worthiness.
-    fromSdist
-    (x: log.traceDebug "${name}.fromSdist ${x.outPath}" x)
   ]

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -84,8 +84,9 @@ in
         lib.filterAttrs (_: cfg: cfg.local.toCurrentProject) config.packages;
 
       finalOverlay = lib.composeManyExtensions [
-        config.packagesOverlay
+        config.packagesOverlays.before
         config.settingsOverlay
+        config.packagesOverlays.after
       ];
 
       finalPackages = config.basePackages.extend finalOverlay;

--- a/nix/modules/project/packages/default.nix
+++ b/nix/modules/project/packages/default.nix
@@ -99,8 +99,6 @@ in
             else
               super.${name};
         in
-        #lib.filterAttrs
-          #  (_: v: v != null)
         (lib.mapAttrs f project.config.packages);
     };
   };


### PR DESCRIPTION
`buildFromSdist` appears to behave oddly so as to invalid user's settings (`jailbreak`, `check`, etc.) from the next overlay.

The solution is to create a 3rd overlay, dedicated to applying `buildFromSdist` and add this overlay after packages and settings overlay.

Resolves #238 ... in particular, I can build @johnhampton's repo. PR is against #251 (which contains the bug repro) for easier review.