### PR TITLE
Make `buildFromSdist` configurable; turn it off by default

### DIFF
--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -12,11 +12,6 @@
 }:
 
 let
-  # NOTE: We do not use the optimized version, `buildFromCabalSdist`, because it
-  # breaks in some cases. See https://github.com/srid/haskell-flake/pull/220
-  fromSdist = pkgs.haskell.lib.buildFromSdist or
-    (log.traceWarning "Your nixpkgs does not have hs.buildFromSdist" (pkg: pkg));
-
   mkNewStorePath = name: src:
     # Since 'src' may be a subdirectory of a store path
     # (in string form, which means that it isn't automatically
@@ -38,9 +33,4 @@ lib.pipe root
 
     (root: self.callCabal2nix name root { })
     (x: log.traceDebug "${name}.cabal2nixDeriver ${x.cabal2nixDeriver.outPath}" x)
-
-    # Make sure all files we use are included in the sdist, as a check
-    # for release-worthiness.
-    fromSdist
-    (x: log.traceDebug "${name}.fromSdist ${x.outPath}" x)
   ]

--- a/nix/modules/project/defaults.nix
+++ b/nix/modules/project/defaults.nix
@@ -84,6 +84,10 @@ in
       '';
       default =
         let
+          globalSettings = {
+            # This breaks a lot of things. So disabling by default.
+            buildFromSdist = lib.mkDefault false;
+          };
           localSettings = { name, package, config, ... }:
             lib.optionalAttrs (package.local.toDefinedProject or false) {
               # Disabling haddock and profiling is mainly to speed up Nix builds.
@@ -91,7 +95,12 @@ in
               libraryProfiling = lib.mkDefault false; # Avoid double-compilation.
             };
         in
-        if config.defaults.enable then localSettings else { };
+        if config.defaults.enable then {
+          imports = [
+            globalSettings
+            localSettings
+          ];
+        } else { };
     };
 
     projectModules.output = mkOption {

--- a/nix/modules/project/settings/all.nix
+++ b/nix/modules/project/settings/all.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, ... }:
+{ name, pkgs, lib, config, log, ... }:
 let
   inherit (lib) types;
   inherit (import ./lib.nix {
@@ -309,6 +309,20 @@ in
         build that is present in the store or cache.  
       '';
       impl = triggerRebuild;
+    };
+    buildFromSdist = {
+      type = types.bool;
+      description = ''
+        Whether to use `buildFromSdist` to build the package.
+        Make sure all files we use are included in the sdist, as a check
+        for release-worthiness.
+      '';
+      impl = enable:
+        if enable then
+          (pkg: lib.pipe pkg [
+            buildFromSdist
+            (x: log.traceDebug "${name}.buildFromSdist ${x.outPath}" x)
+          ]) else x: x;
     };
 
     removeReferencesTo = {

--- a/nix/modules/project/settings/default.nix
+++ b/nix/modules/project/settings/default.nix
@@ -63,6 +63,7 @@ in
               ];
               specialArgs = {
                 inherit name pkgs self super;
+                inherit (project.config) log;
                 package = project.config.packages.${name} or null;
               } // (import ./lib.nix {
                 inherit lib;


### PR DESCRIPTION
Resolves #238 (PR on top of #251 which contains bug repro)

-`settings.<name>.buildFromSdist` is now an option
- default is `false`, because it causes problems with other settings
  - Examples:
    - https://github.com/srid/haskell-flake/issues/238
    - https://github.com/srid/haskell-flake/pull/252#issuecomment-1971633021
  - @roberth is in favour of enabling this by default; @srid tried to fix the above issues in vain, so chooses to disable it in favour of correctness
