### PR TITLE
attrsOf -> lazyAttrsOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Breaking changes
   - #221: Switch to `buildFromSdist`, to allow using non-standard package sets (wherein `cabal-install` is otherwise built without using user's overrides)
   - #253: Turn off `buildFromSdist` by default. It can now be enabled manually by setting `settings.<name>.buildFromSdist` to `true`.
+- #271: Change all `types.attrsOf` to `types.lazyAttrsOf`. If you use `lib.mkIf` for `attrsOf` values (not `submodule` options), use `lib.optionalAttrs` instead. This fixes #270 (`basePackages`) and improves performance.
 
 ## 0.4.0 (Aug 22, 2023)
 

--- a/nix/modules/project-tests.nix
+++ b/nix/modules/project-tests.nix
@@ -17,7 +17,7 @@ in
           will create a flake check automatically.  
         '';
         default = { };
-        type = types.attrsOf (types.submoduleWith {
+        type = types.lazyAttrsOf (types.submoduleWith {
           specialArgs = { inherit pkgs self; };
           modules = [
             {

--- a/nix/modules/project/default.nix
+++ b/nix/modules/project/default.nix
@@ -41,7 +41,7 @@ in
         else cls;
     };
     log = mkOption {
-      type = types.attrsOf (types.functionTo types.raw);
+      type = types.lazyAttrsOf (types.functionTo types.raw);
       default = import ../../logging.nix {
         name = config.projectFlakeName + "#haskellProjects." + name;
       };
@@ -52,7 +52,7 @@ in
       '';
     };
     basePackages = mkOption {
-      type = types.attrsOf raw;
+      type = types.lazyAttrsOf raw;
       description = ''
         Which Haskell package set / compiler to use.
 

--- a/nix/modules/project/devshell.nix
+++ b/nix/modules/project/devshell.nix
@@ -28,7 +28,7 @@ let
         default = hp: { };
       };
       extraLibraries = mkOption {
-        type = types.nullOr (functionTo (types.attrsOf (types.nullOr types.package)));
+        type = types.nullOr (functionTo (types.lazyAttrsOf (types.nullOr types.package)));
         description = ''
           Extra Haskell libraries available in the shell's environment.
           These can be used in the shell's `runghc` and `ghci` for instance.
@@ -43,7 +43,7 @@ let
       };
 
       mkShellArgs = mkOption {
-        type = types.attrsOf types.raw;
+        type = types.lazyAttrsOf types.raw;
         description = ''
           Extra arguments to pass to `pkgs.mkShell`.
         '';

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -16,7 +16,7 @@ let
       };
       finalPackages = mkOption {
         # This must be raw because the Haskell package set also contains functions.
-        type = types.attrsOf types.raw;
+        type = types.lazyAttrsOf types.raw;
         readOnly = true;
         description = ''
           The final Haskell package set including local packages and any
@@ -24,7 +24,7 @@ let
         '';
       };
       packages = mkOption {
-        type = types.attrsOf packageInfoSubmodule;
+        type = types.lazyAttrsOf packageInfoSubmodule;
         readOnly = true;
         description = ''
           Package information for all local packages. Contains the following keys:
@@ -34,7 +34,7 @@ let
         '';
       };
       apps = mkOption {
-        type = types.attrsOf appType;
+        type = types.lazyAttrsOf appType;
         readOnly = true;
         description = ''
           Flake apps for each Cabal executable in the project.
@@ -52,7 +52,7 @@ let
         '';
       };
       exes = mkOption {
-        type = types.attrsOf appType;
+        type = types.lazyAttrsOf appType;
         description = ''
           Attrset of executables from `.cabal` file.  
 

--- a/nix/modules/project/settings/all.nix
+++ b/nix/modules/project/settings/all.nix
@@ -45,7 +45,7 @@ in
         if enable then markBroken else unmarkBroken;
     };
     brokenVersions = {
-      type = types.attrsOf types.str;
+      type = types.lazyAttrsOf types.str;
       description = ''
         List of versions that are known to be broken.
       '';
@@ -200,7 +200,7 @@ in
         removeConfigureFlags;
     };
     cabalFlags = {
-      type = types.attrsOf types.bool;
+      type = types.lazyAttrsOf types.bool;
       description = ''
         Cabal flags to enable or disable explicitly.
       '';

--- a/nix/modules/projects.nix
+++ b/nix/modules/projects.nix
@@ -12,7 +12,7 @@ in
     options = {
       haskellProjects = mkOption {
         description = "Haskell projects";
-        type = types.attrsOf (types.submoduleWith {
+        type = types.lazyAttrsOf (types.submoduleWith {
           specialArgs = { inherit pkgs self; };
           modules = [
             ./project


### PR DESCRIPTION
This means we don't support `mkIf` in the exact places where the type was `attrsOf`. Almost always, `mkIf` can be replaced by `optionalAttrs`.

The benefit is that the code becomes much lazier, improving performance and
- Fixes https://github.com/srid/haskell-flake/issues/270