### PR TITLE
buildFromSdist: deal with breakage of `removeReferencesTo`

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -4,7 +4,7 @@ order: -9
 
 # Package Settings
 
-Settings for individual Haskell packages can be specified in the `settings` attribute of a `haskellProjects` module. 
+Settings for individual Haskell packages can be specified in the `settings` attribute of a `haskellProjects` module.
 
 ```nix
 haskellProjects.default = {
@@ -35,9 +35,10 @@ haskellProjects.default = {
 };
 ```
 
->[!info] Note
+> [!info] Note
+>
 > ### [nixpkgs] functions
-> 
+>
 > - The `pkgs.haskell.lib` module provides various utility functions that you can use to override Haskell packages. The canonical place to find documentation on these is [the source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib/compose.nix). haskell-flake provides a `settings` submodule for convenience. For eg., the `dontCheck` function translates to `settings.<name>.check`; the full list of options can be seen [here](https://github.com/srid/haskell-flake/blob/master/nix/modules/project/settings/all.nix).
 
 ## Sharing package settings {#share}
@@ -46,7 +47,7 @@ haskellProjects.default = {
 
 ## Custom settings {#custom}
 
-You can provide custom settings for use in multiple packages (even across multiple repos). For example, see [this Emanote change](https://github.com/srid/emanote/commit/5b24bd04f94e03afe66ee01da723e4a05d854953) which demonstrates how to add a *new* setting option (`removeReferencesTo`).
+You can provide custom settings for use in multiple packages (even across multiple repos). For example, see [this Emanote change](https://github.com/srid/emanote/commit/5b24bd04f94e03afe66ee01da723e4a05d854953) which demonstrates how to add a _new_ setting option (`removeReferencesTo`).
 
 ## Extra settings {#extra}
 
@@ -57,12 +58,15 @@ haskell-flake provides the following settings on top of those provided by [nixpk
 Remove references to other packages from this Haskell package. This is useful to eliminate unnecessary data dependencies from your Haskell executable so as to reduce its closure size.
 
 > [!info] For more, see
+>
 > - https://github.com/NixOS/nixpkgs/pull/204675
 > - https://srid.ca/remove-references-to
 
 ### `buildFromSdist`
 
-Newer versions of [nixpkgs] provide `buildFromSdist` to build your package from the `cabal sdist` tarball. While this is disabled by default ([see here](https://github.com/srid/haskell-flake/pull/253)), you can enable it by setting `settings.<name>.buildFromSdist` to `true`.
- 
+Newer versions of [nixpkgs] provide `buildFromSdist` to build your package from the `cabal sdist` tarball. This is enabled by default, to help with checking release-worthiness of your packages.
+
+> [!warning] Issues with `buildFromSdist`
+> If you encounter issues with `buildFromSdist` you can disable it by setting `settings.<name>.buildFromSdist` to `true`.
 
 [nixpkgs]: https://nixos.asia/en/nixpkgs

--- a/nix/modules/project/settings/default.nix
+++ b/nix/modules/project/settings/default.nix
@@ -75,8 +75,10 @@ in
             # HACK: buildFromSdist must apply *last*
             # cf. https://github.com/srid/haskell-flake/pull/252
             # In future, we can refactor this as part of https://github.com/srid/haskell-flake/issues/285
-            impl = lib.attrsets.removeAttrs cfg.impl [ "buildFromSdist" ];
-            fns = lib.attrValues impl ++ [ cfg.impl.buildFromSdist ];
+            # NOTE: removeReferencesTo must apply *before* buildFromSdist, because the
+            # later appears it fuck up the former otherwise.
+            impl = lib.attrsets.removeAttrs cfg.impl [ "buildFromSdist" "removeReferencesTo" ];
+            fns = lib.attrValues impl ++ [ cfg.impl.buildFromSdist cfg.impl.removeReferencesTo ];
           in
           lib.pipe super.${name} (
             # TODO: Do we care about the *order* of overrides?


### PR DESCRIPTION
`buildFromSdist` is fucked up for yet another reason. It breaks `removeReferencesTo`:

https://github.com/srid/haskell-flake/blob/4aab279d0cdd25c9bb3a31ca934c98f2d2a2533d/nix/modules/project/settings/all.nix#L340-L347

The solution here is to apply `removeReferencesTo` *after* `buildFromSdist`.
