### PR TITLE
Fix: use `buildFromSdist` for packages managed by haskell-flake only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Breaking changes
   - #221: Switch from `buildFromCabalSdist` to `buildFromSdist`, to allow using non-standard package sets (wherein `cabal-install` is otherwise built without using user's overrides)
-    - #253: Enable controlling `buildFromSdist` through `settings.<name>.buildFromSdist`. (This was turned off by default originally, but was turned on by default in #286, limited to local packages in #298)
+    - #253: Enable controlling `buildFromSdist` through `settings.<name>.buildFromSdist`. (This was turned off by default originally, but was turned on by default in #286, limited to packages defined by haskell-flake in #298 & #306)
 - Enhancements
   - `settings` module:
     - #210: Add `extraLibraries` to `settings` module.

--- a/nix/modules/project/defaults.nix
+++ b/nix/modules/project/defaults.nix
@@ -131,7 +131,8 @@ in
         else { };
 
       defaultText = ''
-        Speed up builds by disabling haddock and library profiling.
+        Speed up builds by disabling haddock and library profiling. Also ensures
+        release-worthiness.
 
         This uses `local.toDefinedProject` option to determine which packages to
         override. Thus, it applies to both local packages as well as
@@ -144,6 +145,7 @@ in
         # Disabling haddock and profiling is mainly to speed up Nix builds.
         haddock = lib.mkDefault false; # Because, this is end-user software. No need for library docs.
         libraryProfiling = lib.mkDefault false; # Avoid double-compilation.
+        buildFromSdist = lib.mkDefault true; # Ensure release-worthiness
       };
     };
 
@@ -191,11 +193,9 @@ in
           }
         else { };
       defaultText = ''
-        Make sure all files we use are included in the sdist, as a check for release-worthiness.
+        Nothing is changed by default.
       '';
-      default = {
-        buildFromSdist = lib.mkDefault true;
-      };
+      default = { };
     };
 
     projectModules.output = mkOption {


### PR DESCRIPTION
See https://github.com/srid/haskell-flake/pull/298#issuecomment-2068516088

