### PR TITLE
Fix: return empty packages if cabal.project detector did not find any

### DIFF
--- a/nix/haskell-parsers/default.nix
+++ b/nix/haskell-parsers/default.nix
@@ -58,7 +58,8 @@ in
               res.value
           else throwErrorOnCabalProjectParseError "Failed to parse ${cabalProjectFile}: ${builtins.toJSON res}"
         else
-          [ projectRoot ];
+          lib.optional (traversal.findSingleCabalFile projectRoot != null)
+            projectRoot;
     in
     lib.listToAttrs
       (map

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -104,6 +104,11 @@ in
             );
       };
 
+      # To fix the following error with lib.mkMerge
+      # error: The option `perSystem.aarch64-darwin.haskellProjects.default.outputs.apps' is used but not defined.
+      mkMergeHandlingEmpty = xs:
+        if xs == [ ] then { } else lib.mkMerge xs;
+
     in
     {
       outputs = {
@@ -112,7 +117,7 @@ in
         packages = lib.mapAttrs buildPackageInfo localPackages;
 
         apps =
-          lib.mkMerge
+          mkMergeHandlingEmpty
             (lib.mapAttrsToList (_: packageInfo: packageInfo.exes) config.outputs.packages);
       };
     };


### PR DESCRIPTION
... instead of failing with inaccurate message (fixed in 462f004 and this PR).

Resolves #213