### PR TITLE
fix: support older nixpkgs

### DIFF
--- a/nix/modules/project/settings/default.nix
+++ b/nix/modules/project/settings/default.nix
@@ -80,7 +80,7 @@ in
             # In future, we can refactor this as part of https://github.com/srid/haskell-flake/issues/285
             # NOTE: removeReferencesTo must apply *before* buildFromSdist, because the
             # later appears it fuck up the former otherwise.
-            impl = lib.attrsets.removeAttrs cfg.impl [ "buildFromSdist" "removeReferencesTo" ];
+            impl = builtins.removeAttrs cfg.impl [ "buildFromSdist" "removeReferencesTo" ];
             fns = lib.attrValues impl ++ [ cfg.impl.buildFromSdist cfg.impl.removeReferencesTo ];
           in
           lib.pipe super.${name} (


### PR DESCRIPTION
lib.attrsets.removeAttrs is only available in newer nixpkgs

This is needed for https://github.com/nammayatri/nammayatri