### PR TITLE
chore(ci): Add `x86_64-*`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
      - uses: actions/checkout@v4
      - id: set-matrix
-       run: echo "matrix=$(nixci gh-matrix --systems=x86_64-linux,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
+       run: echo "matrix=$(nixci gh-matrix --systems=x86_64-linux,x86_64-darwin,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
   nix:
     runs-on: ${{ matrix.system }}
     needs: configure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           nixci \
-            --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
+            --extra-access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}" \
             build \
             --systems "github:nix-systems/${{ matrix.system }}" \
             .#default.${{ matrix.subflake}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,13 @@
 name: "CI"
+
 on:
   push:
     branches:
       - master
   pull_request:
+
 jobs:
+  
   configure:
     runs-on: x86_64-linux
     outputs:
@@ -13,6 +16,7 @@ jobs:
      - uses: actions/checkout@v4
      - id: set-matrix
        run: echo "matrix=$(nixci gh-matrix --systems=x86_64-linux,x86_64-darwin,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
+  
   nix:
     runs-on: ${{ matrix.system }}
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,19 +6,19 @@ on:
   pull_request:
 jobs:
   configure:
-    runs-on: self-hosted
+    runs-on: x86_64-linux
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
      - uses: actions/checkout@v4
      - id: set-matrix
-       run: echo "matrix=$(nixci gh-matrix --systems=aarch64-linux,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
+       run: echo "matrix=$(nixci gh-matrix --systems=x86_64-linux,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
   nix:
-    runs-on: self-hosted
+    runs-on: ${{ matrix.system }}
     needs: configure
     strategy:
       matrix: ${{ fromJson(needs.configure.outputs.matrix) }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - run: nixci build --systems "github:nix-systems/${{ matrix.system }}" .#default.${{ matrix.subflake}}
+      - run: nixci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} build --systems "github:nix-systems/${{ matrix.system }}" .#default.${{ matrix.subflake}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,5 +27,5 @@ jobs:
           nixci \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
             build \
-            --systems "github:nix-systems/${{ matrix.system }}" \
+            --systems "${{ matrix.system }}" \
             .#default.${{ matrix.subflake}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,4 +21,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - run: nixci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} build --systems "github:nix-systems/${{ matrix.system }}" .#default.${{ matrix.subflake}}
+      - run: |
+          nixci --version
+          nixci \
+            --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
+            build \
+            --systems "github:nix-systems/${{ matrix.system }}" \
+            .#default.${{ matrix.subflake}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
        run: echo "matrix=$(nixci gh-matrix --systems=x86_64-linux,x86_64-darwin,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
   nix:
     runs-on: ${{ matrix.system }}
+    permissions:
+      contents: read
     needs: configure
     strategy:
       matrix: ${{ fromJson(needs.configure.outputs.matrix) }}
@@ -22,7 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          nixci --version
           nixci \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
             build \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,5 +27,5 @@ jobs:
           nixci \
             --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} \
             build \
-            --systems "${{ matrix.system }}" \
+            --systems "github:nix-systems/${{ matrix.system }}" \
             .#default.${{ matrix.subflake}}


### PR DESCRIPTION
Drop `aarch64-linux`.

---

And pass access-token to prevent github rate limits. This requires adding,

```yaml
    permissions:
      contents: read
```

and passing the following argument to `nixci:

```sh
--extra-access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}"
```