### PR TITLE
Add missing semicolon to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The minimal changes to your `flake.nix` to introduce the `haskell-flake` and [`f
 
           # Packages to add on top of `basePackages`, e.g. from Hackage
           packages = {
-            aeson.source = "1.5.0.0" # Hackage version
+            aeson.source = "1.5.0.0"; # Hackage version
           };
 
           # my-haskell-package development shell configuration


### PR DESCRIPTION
This a very, very tiny pull request, that adds a comment to the flake template presented in the README.md file.
It has a missing semicolon, which has to be added by readers who copy-paste it, which is a bit annoying.