### PR TITLE
Add `meta.description` to flake apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for haskell-flake
 
+## Unreleased
+
+- Enhancements
+  - Support `meta.description` in flake apps. Requires newer version of flake-parts.
+
 ## 0.5.0 (Jun 24, 2024)
 
 - Breaking changes

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -5,6 +5,7 @@ license:         NONE
 author:          Joe
 maintainer:      joe@example.com
 build-type:      Simple
+synopsis:           A template for Haskell projects using Nix
 
 common warnings
     ghc-options: -Wall

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -5,7 +5,6 @@ license:         NONE
 author:          Joe
 maintainer:      joe@example.com
 build-type:      Simple
-synopsis:           A template for Haskell projects using Nix
 
 common warnings
     ghc-options: -Wall

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -54,7 +54,7 @@ let
       exes = mkOption {
         type = types.lazyAttrsOf appType;
         description = ''
-          Attrset of executables from `.cabal` file.  
+          Attrset of executables from `.cabal` file.
 
           If the associated Haskell project has a separate bin output
           (cf. `enableSeparateBinOutput`), then this exe will refer
@@ -90,15 +90,19 @@ in
 
       finalPackages = config.basePackages.extend finalOverlay;
 
-      buildPackageInfo = name: value: {
+      buildPackageInfo = name: value: rec {
         package = finalPackages.${name};
         exes =
           lib.listToAttrs
             (map
               (exe:
-                lib.nameValuePair exe {
-                  program = "${lib.getBin finalPackages.${name}}/bin/${exe}";
-                }
+                lib.nameValuePair exe ({
+                  program = "${lib.getBin package}/bin/${exe}";
+                  meta.description =
+                    if (exe != name && lib.hasAttrByPath [ "meta" "description" ] package)
+                    then package.meta.description
+                    else "Executable ${exe} from package ${name}";
+                })
               )
               value.cabal.executables
             );
@@ -122,4 +126,3 @@ in
       };
     };
 }
-

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -100,7 +100,7 @@ in
                   program = "${lib.getBin package}/bin/${exe}";
                   meta.description =
                     if lib.hasAttrByPath [ "meta" "description" ] package
-                    then "${if exe != name then "[${exe}] " else ""}${meta.description}";
+                    then "${if exe != name then "[${exe}] " else ""}${meta.description}"
                     else "Executable ${if exe != name then "${exe} from " else "for "}package ${name}";
                 })
               )

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -99,9 +99,9 @@ in
                 lib.nameValuePair exe ({
                   program = "${lib.getBin package}/bin/${exe}";
                   meta.description =
-                    if (exe != name && lib.hasAttrByPath [ "meta" "description" ] package)
-                    then package.meta.description
-                    else "Executable ${exe} from package ${name}";
+                    if (exe != name && !lib.hasAttrByPath [ "meta" "description" ] package)
+                    then "Executable ${exe} from package ${name}"
+                    else package.meta.description;
                 })
               )
               value.cabal.executables

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -100,7 +100,7 @@ in
                   program = "${lib.getBin package}/bin/${exe}";
                   meta.description =
                     if lib.hasAttrByPath [ "meta" "description" ] package
-                    then "${if exe != name then "[${exe}] " else ""}${meta.description}"
+                    then "${if exe != name then "[${exe}] " else ""}${package.meta.description}"
                     else "Executable ${if exe != name then "${exe} from " else "for "}package ${name}";
                 })
               )

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -100,7 +100,7 @@ in
                   program = "${lib.getBin package}/bin/${exe}";
                   meta.description =
                     if lib.hasAttrByPath [ "meta" "description" ] package
-                    then package.meta.description
+                    then "${if exe != name then "[${exe}] " else ""}${meta.description}";
                     else "Executable ${if exe != name then "${exe} from " else "for "}package ${name}";
                 })
               )

--- a/nix/modules/project/outputs.nix
+++ b/nix/modules/project/outputs.nix
@@ -99,9 +99,9 @@ in
                 lib.nameValuePair exe ({
                   program = "${lib.getBin package}/bin/${exe}";
                   meta.description =
-                    if (exe != name && !lib.hasAttrByPath [ "meta" "description" ] package)
-                    then "Executable ${exe} from package ${name}"
-                    else package.meta.description;
+                    if lib.hasAttrByPath [ "meta" "description" ] package
+                    then package.meta.description
+                    else "Executable ${if exe != name then "${exe} from " else "for "}package ${name}";
                 })
               )
               value.cabal.executables

--- a/nix/types/app-type.nix
+++ b/nix/types/app-type.nix
@@ -24,6 +24,17 @@ let
           A path to an executable or a derivation with `meta.mainProgram`.
         '';
       };
+      meta = lib.mkOption {
+        type = lib.types.lazyAttrsOf lib.types.raw;
+        default = { };
+        # TODO refer to Nix manual 2.25
+        description = ''
+          Metadata information about the app.
+          Standardized in Nix at <https://github.com/NixOS/nix/pull/11297>.
+
+          Note: `nix flake check` is only aware of the `description` attribute in `meta`.
+        '';
+      };
     };
   };
 in


### PR DESCRIPTION
Supporting https://github.com/hercules-ci/flake-parts/pull/240

Tested with https://github.com/juspay/omnix/pull/251

Running https://omnix.page/om/show.html ..

on Emanote:

<img width="755" alt="image" src="https://github.com/user-attachments/assets/3b7b91f2-4630-48e3-b95f-3c638a079efe">

on Nammayatri

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/90a433f8-6ec8-43ab-a095-f10b869ae47b">

