### PR TITLE
Add `extraCabal2nixOptions` and `cabalFlags` to `packages.<package>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enhancements
   - #382: Support for cabal2nix generated expressions (avoiding IFD for local packages)
+  - Add `extraCabal2nixOptions` and `cabalFlags` to `packages.*`. The former passes custom options to `cabal2nix`. The later does the same, but formatting the flag options appropriately.
   - Support `meta.description` in flake apps. Requires newer version of flake-parts.
   - `settings` module:
     - #384: Add `stan`

--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -55,6 +55,14 @@ name: cfg:
 # If 'source' is a path, we treat it as such. Otherwise, we assume it's a version (from hackage).
 if lib.types.path.check cfg.source
 then
-  callCabal2NixUnlessCached name (mkNewStorePath name cfg.source) cfg.cabal2NixFile cfg.extraCabal2nixOptions
+  let
+    cfgCabalFlags =
+      lib.mapAttrsToList
+        (flag: enabled: "-f${if enabled then "" else "-"}${flag}")
+        cfg.cabalFlags;
+    extraCabal2nixOptions =
+      lib.strings.concatStringsSep " " (cfgCabalFlags ++ cfg.extraCabal2nixOptions);
+  in
+  callCabal2NixUnlessCached name (mkNewStorePath name cfg.source) cfg.cabal2NixFile extraCabal2nixOptions
 else
   callHackage name cfg.source

--- a/nix/build-haskell-package.nix
+++ b/nix/build-haskell-package.nix
@@ -28,19 +28,19 @@ let
     let newSrc = mkNewStorePath' name src;
     in log.traceDebug "${name}.mkNewStorePath ${newSrc}" newSrc;
 
-  callCabal2nix = name: src:
-    let pkg = self.callCabal2nix name src { };
-    in log.traceDebug "${name}.callCabal2nix src=${src} deriver=${pkg.cabal2nixDeriver.outPath}" pkg;
+  callCabal2nix = name: src: opts:
+    let pkg = self.callCabal2nixWithOptions name src { extraCabal2nixOptions = opts; } { };
+    in log.traceDebug "${name}.callCabal2nixWithOptions src=${src} deriver=${pkg.cabal2nixDeriver.outPath} opts=${opts}" pkg;
 
   # Use cached cabal2nix generated nix expression if present, otherwise use IFD (callCabal2nix)
-  callCabal2NixUnlessCached = name: src: cabal2nixFile:
+  callCabal2NixUnlessCached = name: src: cabal2nixFile: opts:
     let path = "${src}/${cabal2nixFile}";
     in
     if builtins.pathExists path
     then
       callPackage name path
     else
-      callCabal2nix name src;
+      callCabal2nix name src opts;
 
   callPackage = name: nixFilePath:
     let pkg = self.callPackage nixFilePath { };
@@ -55,6 +55,6 @@ name: cfg:
 # If 'source' is a path, we treat it as such. Otherwise, we assume it's a version (from hackage).
 if lib.types.path.check cfg.source
 then
-  callCabal2NixUnlessCached name (mkNewStorePath name cfg.source) cfg.cabal2NixFile
+  callCabal2NixUnlessCached name (mkNewStorePath name cfg.source) cfg.cabal2NixFile cfg.extraCabal2nixOptions
 else
   callHackage name cfg.source

--- a/nix/modules/project/packages/package.nix
+++ b/nix/modules/project/packages/package.nix
@@ -97,9 +97,6 @@ in
         List of extra options given to cabal2nix.
       '';
       default = [ ];
-      apply =
-        flags:
-        lib.strings.concatStringsSep " " (config.cabalFlags ++ flags);
     };
 
     cabalFlags = mkOption {
@@ -108,9 +105,6 @@ in
         Cabal flags to enable or disable explicitly when calling cabal2nix.
       '';
       default = { };
-      apply =
-        lib.mapAttrsToList
-          (flag: enabled: "-f${if enabled then "" else "-"}${flag}");
     };
   };
 }

--- a/nix/modules/project/packages/package.nix
+++ b/nix/modules/project/packages/package.nix
@@ -90,5 +90,27 @@ in
         defining project.
       '';
     };
+
+    extraCabal2nixOptions = mkOption {
+      type = types.listOf types.str;
+      description = ''
+        List of extra options given to cabal2nix.
+      '';
+      default = [];
+      apply =
+        flags:
+          lib.strings.concatStringsSep " " (config.cabalFlags ++ flags);
+    };
+
+    cabalFlags = mkOption {
+      type = types.lazyAttrsOf types.bool;
+      description = ''
+        Cabal flags to enable or disable explicitly when calling cabal2nix.
+      '';
+      default = {};
+      apply =
+        lib.mapAttrsToList
+          (flag: enabled: "-f${if enabled then "" else "-"}${flag}");
+    };
   };
 }

--- a/nix/modules/project/packages/package.nix
+++ b/nix/modules/project/packages/package.nix
@@ -96,10 +96,10 @@ in
       description = ''
         List of extra options given to cabal2nix.
       '';
-      default = [];
+      default = [ ];
       apply =
         flags:
-          lib.strings.concatStringsSep " " (config.cabalFlags ++ flags);
+        lib.strings.concatStringsSep " " (config.cabalFlags ++ flags);
     };
 
     cabalFlags = mkOption {
@@ -107,7 +107,7 @@ in
       description = ''
         Cabal flags to enable or disable explicitly when calling cabal2nix.
       '';
-      default = {};
+      default = { };
       apply =
         lib.mapAttrsToList
           (flag: enabled: "-f${if enabled then "" else "-"}${flag}");

--- a/nix/modules/project/settings/all.nix
+++ b/nix/modules/project/settings/all.nix
@@ -203,6 +203,8 @@ in
       type = types.lazyAttrsOf types.bool;
       description = ''
         Cabal flags to enable or disable explicitly.
+
+        NOTE: You may wish to use `packages.*.cabalFlags` instead, as those are passed directly to `cabal2nix` (see #418).
       '';
       impl = flags: drv:
         let


### PR DESCRIPTION
Settings such as `settings.<package>.cabalFlags` happen after `cabal2nix` which can be too late when the dependencies depend on a flag.

The option `packages.<package>.cabalFlags` can safely be used instead of `settings.<package>.cabalFlags` in most situations.

Additionally the option `packages.<package>.extraCabal2nixOptions` provides a direct access the options given to cabal2nix.