### PR TITLE
buildFromSdist: Test if user can override the `jailbreak` setting

### DIFF
--- a/test/simple/flake.nix
+++ b/test/simple/flake.nix
@@ -51,8 +51,12 @@
               jailbreak = true;
               cabalFlags.blah = true;
             };
-            # Test STatic ANalysis report generation
-            haskell-flake-test.stan = true;
+            haskell-flake-test = {
+              # Test STatic ANalysis report generation
+              stan = true;
+              # Test if user's setting overrides the `jailbreak = false;` override by `buildFromSdist`
+              jailbreak = true;
+            };
           };
           devShell = {
             tools = hp: {

--- a/test/simple/flake.nix
+++ b/test/simple/flake.nix
@@ -54,7 +54,9 @@
             haskell-flake-test = {
               # Test STatic ANalysis report generation
               stan = true;
-              # Test if user's setting overrides the `jailbreak = false;` override by `buildFromSdist`
+              # Test if user's setting overrides the `jailbreak = false;` override by `buildFromSdist`.
+              # 
+              # This jailbreak ignores the unsatisfiable version constraints on the library `foo`.
               jailbreak = true;
             };
           };

--- a/test/simple/haskell-flake-test.cabal
+++ b/test/simple/haskell-flake-test.cabal
@@ -14,6 +14,7 @@ executable haskell-flake-test
     main-is:          Main.hs
     build-depends:    
         base,
-        foo >= 0.2  -- To test `jailbreak` in flake
+        -- Add version constraint to test `jailbreak` in flake
+        foo >= 0.2
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/test/simple/haskell-flake-test.cabal
+++ b/test/simple/haskell-flake-test.cabal
@@ -14,6 +14,10 @@ executable haskell-flake-test
     main-is:          Main.hs
     build-depends:    
         base,
+        -- Add a version constraint that fails unless jailbroken.
+        --
+        -- This exists to test if the user's setting to enable `jailbreak` paramounts
+        -- `buildFromSdist`'s setting to disable it
         foo >= 0.2
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/test/simple/haskell-flake-test.cabal
+++ b/test/simple/haskell-flake-test.cabal
@@ -14,6 +14,6 @@ executable haskell-flake-test
     main-is:          Main.hs
     build-depends:    
         base,
-        foo
+        foo >= 0.2
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/test/simple/haskell-flake-test.cabal
+++ b/test/simple/haskell-flake-test.cabal
@@ -14,6 +14,6 @@ executable haskell-flake-test
     main-is:          Main.hs
     build-depends:    
         base,
-        foo >= 0.2
+        foo >= 0.2  -- To test `jailbreak` in flake
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/test/simple/haskell-flake-test.cabal
+++ b/test/simple/haskell-flake-test.cabal
@@ -14,7 +14,6 @@ executable haskell-flake-test
     main-is:          Main.hs
     build-depends:    
         base,
-        -- Add version constraint to test `jailbreak` in flake
         foo >= 0.2
     hs-source-dirs:   src
     default-language: Haskell2010


### PR DESCRIPTION
Adds one of the tests mentioned in the description of https://github.com/srid/haskell-flake/issues/262

The existing jailbreak test `foo.jailbreak = true;` doesn't test the expected behaviour because `foo`'s `cabal` file has no dependencies requiring jailbreak