### PR TITLE
ci: Combine subflakes, and ignore arm linux/ intel mac

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ jobs:
         include:
           - system: x86_64-linux
           - system: aarch64-darwin
-          - system: x86_64-darwin
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
My CI is limited right now. If we really need these platforms (with reason), I'll add it back.