### PR TITLE
Support using haskell-flake without flake-parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Enhancements
+  - #495: Add `lib.evalHaskellProject` for using haskell-flake without flake-parts. Also fixes `hls-check.nix` to use `config.projectRoot` instead of `self`.
   - #382: Support for cabal2nix generated expressions (avoiding IFD for local packages)
   - #418: Add `extraCabal2nixOptions` and `cabalFlags` to `packages.*`. The former passes custom options to `cabal2nix`. The later does the same, but formatting the flag options appropriately.
   - #356: Support `meta.description` in flake apps. Requires newer version of flake-parts.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://nixos.zulipchat.com/#narrow/stream/413949-haskell-flake)
 [![Naiveté Compass of Mood](https://img.shields.io/badge/naïve-FF10F0)](https://srid.ca/coc "This project follows the 'Naiveté Compass of Mood'")
 
-# haskell-flake - Manage Haskell projects conveniently with Nix
+# haskell-flake - Ergonomic Nix module for Haskell development
 
 <img src="./doc/haskell-flake.webp" width=100 />
 
-There are [several ways](https://nixos.asia/en/haskell) to manage Haskell packages using [Nix](https://nixos.asia/en/nix) with varying degrees of integration.  `haskell-flake` makes Haskell development, packaging and deployment with Nix flakes a lot [simpler](https://community.flake.parts/haskell-flake/start#under-the-hood) than other existing approaches.  This project is set up as a modern [`flake-parts`](https://flake.parts/) module to integrate easily into other Nix projects and shell development environments in a lightweight and modular way.[^standalone]
-
-[^standalone]: `flake-parts` is not required. haskell-flake also provides a [standalone API](https://community.flake.parts/haskell-flake/standalone) (`lib.evalHaskellProject`) for use in plain flakes or legacy Nix.
+There are [several ways](https://nixos.asia/en/haskell) to manage Haskell packages using [Nix](https://nixos.asia/en/nix) with varying degrees of integration. `haskell-flake` makes Haskell development, packaging and deployment with Nix a lot [simpler](https://community.flake.parts/haskell-flake/start#under-the-hood) than other existing approaches. It works with plain Nix (no flakes), Nix flakes, or as a [`flake-parts`](https://flake.parts/) module—choose whichever fits your project.
 
 To see more background information, guides and best practices, visit https://community.flake.parts/haskell-flake
 
@@ -17,7 +15,9 @@ so your project must have a top-level `.cabal` file (single package project) or 
 
 ## Getting started
 
-The minimal changes to your `flake.nix` to introduce the `haskell-flake` and [`flake-parts`](https://flake.parts/) modules will look similar to:
+The guide below uses [flake-parts](https://flake.parts/); for other approaches see [standalone usage](https://community.flake.parts/haskell-flake/standalone).
+
+The minimal changes to your `flake.nix` to introduce `haskell-flake` with flake-parts will look similar to:
 
 ```nix
 # file: flake.nix

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 <img src="./doc/haskell-flake.webp" width=100 />
 
-There are [several ways](https://nixos.asia/en/haskell) to manage Haskell packages using [Nix](https://nixos.asia/en/nix) with varying degrees of integration.  `haskell-flake` makes Haskell development, packaging and deployment with Nix flakes a lot [simpler](https://community.flake.parts/haskell-flake/start#under-the-hood) than other existing approaches.  This project is set up as a modern [`flake-parts`](https://flake.parts/) module to integrate easily into other Nix projects and shell development environments in a lightweight and modular way.
+There are [several ways](https://nixos.asia/en/haskell) to manage Haskell packages using [Nix](https://nixos.asia/en/nix) with varying degrees of integration.  `haskell-flake` makes Haskell development, packaging and deployment with Nix flakes a lot [simpler](https://community.flake.parts/haskell-flake/start#under-the-hood) than other existing approaches.  This project is set up as a modern [`flake-parts`](https://flake.parts/) module to integrate easily into other Nix projects and shell development environments in a lightweight and modular way.[^standalone]
+
+[^standalone]: `flake-parts` is not required. haskell-flake also provides a [standalone API](https://community.flake.parts/haskell-flake/standalone) (`lib.evalHaskellProject`) for use in plain flakes or legacy Nix.
 
 To see more background information, guides and best practices, visit https://community.flake.parts/haskell-flake
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -13,4 +13,5 @@ order: -9
 - [[modules]]#
 - [[debugging]]#
 - [[incremental-builds]]#
+- [[standalone]]#
 - [[size]]#

--- a/doc/index.md
+++ b/doc/index.md
@@ -9,7 +9,9 @@ emanote:
 
 # Haskell development using `haskell-flake`
 
-[haskell-flake](https://github.com/srid/haskell-flake) is a [flake-parts](https://flake.parts/) module to make Haskell development [[under-the-hood|simpler]] with [Nix](https://nixos.asia/en/nix).
+[haskell-flake](https://github.com/srid/haskell-flake) is a [flake-parts](https://flake.parts/) module[^standalone] to make Haskell development [[under-the-hood|simpler]] with [Nix](https://nixos.asia/en/nix).
+
+[^standalone]: `flake-parts` is not required. haskell-flake also provides a [[standalone|standalone API]] for use in plain flakes or legacy Nix.
 
 To get started, see [[start]]# and thereon see [[guide]]#. To get inspired, see [[examples]]#. For reference, see [[ref]]#.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -9,9 +9,7 @@ emanote:
 
 # Haskell development using `haskell-flake`
 
-[haskell-flake](https://github.com/srid/haskell-flake) is a [flake-parts](https://flake.parts/) module[^standalone] to make Haskell development [[under-the-hood|simpler]] with [Nix](https://nixos.asia/en/nix).
-
-[^standalone]: `flake-parts` is not required. haskell-flake also provides a [[standalone|standalone API]] for use in plain flakes or legacy Nix.
+[haskell-flake](https://github.com/srid/haskell-flake) is an ergonomic [Nix](https://nixos.asia/en/nix) module for Haskell development that makes things [[under-the-hood|simpler]]. It works with plain Nix (no flakes), Nix flakes, or as a [flake-parts](https://flake.parts/) module (see [[standalone]] for non-flake-parts usage).
 
 To get started, see [[start]]# and thereon see [[guide]]#. To get inspired, see [[examples]]#. For reference, see [[ref]]#.
 

--- a/doc/standalone.md
+++ b/doc/standalone.md
@@ -1,0 +1,81 @@
+---
+order: 1
+---
+
+# Standalone usage (without flake-parts)
+
+haskell-flake can be used without [flake-parts](https://flake.parts/) via the `lib.evalHaskellProject` function. This is useful if you have a plain flake or a legacy (non-flakes) Nix setup.
+
+## Plain flake
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    haskell-flake.url = "github:srid/haskell-flake";
+  };
+  outputs = { self, nixpkgs, haskell-flake, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
+        projectRoot = self;
+        modules = [{
+          # Same options as haskellProjects.default = { ... }
+          settings = {
+            mypackage.haddock = false;
+          };
+          devShell.tools = hp: {
+            inherit (hp) fourmolu;
+          };
+        }];
+      };
+    in
+    {
+      packages.${system}.default = project.packages.mypackage.package;
+      devShells.${system}.default = project.devShell;
+    };
+}
+```
+
+## API
+
+`haskell-flake.lib` is a function that takes `{ pkgs }` and returns an attribute set with:
+
+### `evalHaskellProject`
+
+```
+{ projectRoot, name ? "default", modules ? [] } -> outputs
+```
+
+- **`projectRoot`** (required): Path to the project directory containing `.cabal` or `cabal.project` files.
+- **`name`**: Project name, defaults to `"default"`.
+- **`modules`**: List of modules with the same options available under `haskellProjects.<name>` in the flake-parts interface (e.g., `packages`, `settings`, `devShell`, `basePackages`, `otherOverlays`).
+
+Returns the project outputs:
+
+| Output | Description |
+|---|---|
+| `finalOverlay` | The composed Haskell overlay |
+| `finalPackages` | The Haskell package set with all overlays applied |
+| `packages` | Attrset of `{ package, exes }` for each local package |
+| `apps` | Flake apps for each Cabal executable |
+| `devShell` | Development shell derivation |
+| `checks` | Flake checks (e.g., HLS check if enabled) |
+
+## Without flakes
+
+You can also use haskell-flake from traditional Nix (no flakes):
+
+```nix
+let
+  haskell-flake = builtins.fetchTarball {
+    url = "https://github.com/srid/haskell-flake/archive/master.tar.gz";
+  };
+  pkgs = import <nixpkgs> {};
+  project = (import "${haskell-flake}/nix/lib.nix" { inherit pkgs; }).evalHaskellProject {
+    projectRoot = ./.;
+  };
+in
+  project.packages.mypackage.package
+```

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A `flake-parts` module for Haskell development";
+  description = "Nix library for Haskell development (standalone or as a flake-parts module)";
   outputs = inputs: {
     flakeModule = ./nix/modules;
     lib = import ./nix/lib.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "A `flake-parts` module for Haskell development";
   outputs = inputs: {
     flakeModule = ./nix/modules;
+    lib = import ./nix/lib.nix;
 
     templates.default = {
       description = "A simple flake.nix using haskell-flake";

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,28 @@
+# Standalone API for using haskell-flake without flake-parts.
+#
+# Usage:
+#   let
+#     project = (import haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
+#       projectRoot = ./.;
+#       modules = [{ settings.mypkg.haddock = false; }];
+#     };
+#   in project.packages.mypkg.package
+{ pkgs, lib ? pkgs.lib }:
+
+{
+  # Evaluate a haskell-flake project configuration and return its outputs.
+  #
+  # Returns: { finalOverlay, finalPackages, packages, apps, devShell, checks }
+  evalHaskellProject =
+    { projectRoot
+    , name ? "default"
+    , modules ? [ ]
+    }:
+    (lib.evalModules {
+      specialArgs = { inherit pkgs name; };
+      modules = [
+        ./modules/project
+        { inherit projectRoot; }
+      ] ++ modules;
+    }).config.outputs;
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,12 +1,18 @@
 # Standalone API for using haskell-flake without flake-parts.
 #
-# Usage:
+# In a flake:
 #   let
-#     project = (import haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
-#       projectRoot = ./.;
-#       modules = [{ settings.mypkg.haddock = false; }];
+#     project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
+#       projectRoot = self;
 #     };
-#   in project.packages.mypkg.package
+#   in project.packages.mypackage.package
+#
+# Without flakes:
+#   let
+#     project = (import /path/to/haskell-flake/nix/lib.nix { inherit pkgs; }).evalHaskellProject {
+#       projectRoot = ./.;
+#     };
+#   in project.packages.mypackage.package
 { pkgs, lib ? pkgs.lib }:
 
 {

--- a/nix/modules/project-tests.nix
+++ b/nix/modules/project-tests.nix
@@ -18,7 +18,7 @@ in
         '';
         default = { };
         type = types.lazyAttrsOf (types.submoduleWith {
-          specialArgs = { inherit pkgs self; };
+          specialArgs = { inherit pkgs; };
           modules = [
             {
               options = {

--- a/nix/modules/project/default.nix
+++ b/nix/modules/project/default.nix
@@ -1,5 +1,5 @@
 # Definition of the `haskellProjects.${name}` submodule's `config`
-{ self, name, config, lib, pkgs, ... }:
+{ name, config, lib, pkgs, ... }:
 let
   inherit (lib)
     mkOption
@@ -21,11 +21,9 @@ in
       description = ''
         Path to the root of the project directory.
 
-        Chaning this affects certain functionality, like where to
+        Changing this affects certain functionality, like where to
         look for the 'cabal.project' file.
       '';
-      default = self;
-      defaultText = "Top-level directory of the flake";
     };
     projectFlakeName = mkOption {
       type = types.nullOr types.str;

--- a/nix/modules/project/hls-check.nix
+++ b/nix/modules/project/hls-check.nix
@@ -1,5 +1,5 @@
 # Definition of the `haskellProjects.${name}` submodule's `config`
-{ name, self, config, lib, pkgs, ... }:
+{ name, config, lib, pkgs, ... }:
 let
   inherit (lib)
     mkOption
@@ -82,7 +82,7 @@ in
       hlsCheck =
         runCommandInSimulatedShell
           config.outputs.devShell
-          self "${projectKey}-hls-check"
+          config.projectRoot "${projectKey}-hls-check"
           { } "haskell-language-server";
     in
     {

--- a/nix/modules/projects.nix
+++ b/nix/modules/projects.nix
@@ -13,9 +13,10 @@ in
       haskellProjects = mkOption {
         description = "Haskell projects";
         type = types.lazyAttrsOf (types.submoduleWith {
-          specialArgs = { inherit pkgs self; };
+          specialArgs = { inherit pkgs; };
           modules = [
             ./project
+            { projectRoot = lib.mkDefault self; }
           ];
         });
       };

--- a/test/standalone/flake.nix
+++ b/test/standalone/flake.nix
@@ -1,0 +1,51 @@
+{
+  # Test: use haskell-flake without flake-parts, via the standalone lib API.
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/870493f9a8cb0b074ae5b411b2f232015db19a65";
+    haskell-flake = { };
+  };
+  outputs = { self, nixpkgs, haskell-flake, ... }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+    in
+    {
+      packages = eachSystem (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
+            projectRoot = self;
+          };
+        in
+        {
+          default = project.packages.haskell-flake-test.package;
+        });
+
+      devShells = eachSystem (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
+            projectRoot = self;
+          };
+        in
+        {
+          default = project.devShell;
+        });
+
+      checks = eachSystem (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
+            projectRoot = self;
+          };
+        in
+        {
+          test = pkgs.runCommandNoCC "standalone-test"
+            { }
+            ''
+              ${project.packages.haskell-flake-test.package}/bin/haskell-flake-test \
+                | grep "Hello from standalone"
+              touch $out
+            '';
+        });
+    };
+}

--- a/test/standalone/flake.nix
+++ b/test/standalone/flake.nix
@@ -7,45 +7,29 @@
   outputs = { self, nixpkgs, haskell-flake, ... }:
     let
       eachSystem = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+
+      perSystem = system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
+            projectRoot = self;
+          };
+        in
+        {
+          packages.default = project.packages.haskell-flake-test.package;
+          devShells.default = project.devShell;
+          checks.test = pkgs.runCommandNoCC "standalone-test" { } ''
+            ${project.packages.haskell-flake-test.package}/bin/haskell-flake-test \
+              | grep "Hello from standalone"
+            touch $out
+          '';
+        };
+
+      systemOutputs = eachSystem perSystem;
     in
     {
-      packages = eachSystem (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
-            projectRoot = self;
-          };
-        in
-        {
-          default = project.packages.haskell-flake-test.package;
-        });
-
-      devShells = eachSystem (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
-            projectRoot = self;
-          };
-        in
-        {
-          default = project.devShell;
-        });
-
-      checks = eachSystem (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
-            projectRoot = self;
-          };
-        in
-        {
-          test = pkgs.runCommandNoCC "standalone-test"
-            { }
-            ''
-              ${project.packages.haskell-flake-test.package}/bin/haskell-flake-test \
-                | grep "Hello from standalone"
-              touch $out
-            '';
-        });
+      packages = nixpkgs.lib.mapAttrs (_: s: s.packages) systemOutputs;
+      devShells = nixpkgs.lib.mapAttrs (_: s: s.devShells) systemOutputs;
+      checks = nixpkgs.lib.mapAttrs (_: s: s.checks) systemOutputs;
     };
 }

--- a/test/standalone/haskell-flake-test.cabal
+++ b/test/standalone/haskell-flake-test.cabal
@@ -1,0 +1,17 @@
+cabal-version:   3.0
+name:            haskell-flake-test
+version:         0.1.0.0
+license:         NONE
+author:          Joe
+maintainer:      joe@example.com
+build-type:      Simple
+
+common warnings
+    ghc-options: -Wall
+
+executable haskell-flake-test
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/test/standalone/src/Main.hs
+++ b/test/standalone/src/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello from standalone haskell-flake!"

--- a/vira.hs
+++ b/vira.hs
@@ -19,6 +19,7 @@
          , "./test/project-module" { overrideInputs = hf }
          , "./test/settings-defaults" { overrideInputs = hf }
          , "./test/otherOverlays" { overrideInputs = hf }
+         , "./test/standalone" { overrideInputs = hf }
          ]
      , signoff.enable = True
      , cache.url = if isMaster then Just "https://cache.nixos.asia/oss" else Nothing


### PR DESCRIPTION
**haskell-flake can now be used standalone**, without requiring flake-parts as a framework. A new `lib.evalHaskellProject` function evaluates project configuration directly via `lib.evalModules`, returning the same outputs (packages, devShell, overlay, apps, checks) that the flake-parts module produces.

The project submodule was already *nearly* self-contained — it only depended on flake-parts through the `self` specialArg used as default for `projectRoot`. This PR removes that coupling: `projectRoot` no longer has a default in the submodule, and the flake-parts wrapper injects `projectRoot = lib.mkDefault self` to preserve existing behavior. *This also fixes a latent bug in `hls-check.nix` where `self` was used instead of `config.projectRoot`, which would be wrong whenever `projectRoot` is overridden.*

Follows the pattern established by [process-compose-flake#80](https://github.com/Platonic-Systems/process-compose-flake/pull/80).

### Try it locally

```nix
let
  project = (haskell-flake.lib { inherit pkgs; }).evalHaskellProject {
    projectRoot = self;
  };
in project.packages.mypackage.package
```