### PR TITLE
Deploy Emanote docs to GitHub Pages

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,37 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v33
+      - name: Build Emanote site
+        run: nix --accept-flake-config build ./doc -o ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**Adds a GitHub Actions workflow that builds and deploys the Emanote documentation site** on every push to master. The `doc/` directory already contains a full Emanote site wired through the `cfp` (community.flake.parts) flake module — this workflow runs `nix build ./doc` and pushes the result to GitHub Pages via `actions/deploy-pages`.

The workflow mirrors the [emanote-template](https://github.com/srid/emanote-template) pattern: Nix builds the static site, `upload-pages-artifact` stages it, and a separate deploy job publishes it. *Uses `--accept-flake-config` so the cachix substituter from `doc/flake.nix` is respected without extra setup.*

> **Note:** GitHub Pages must be enabled in the repo settings with source set to "GitHub Actions" for the deployment to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)