### PR TITLE
Test removeReferencesTo survives buildFromSdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist-newstyle
 
 # APM dependencies
 apm_modules/
+.do-results.json

--- a/test/simple/flake.nix
+++ b/test/simple/flake.nix
@@ -62,10 +62,12 @@
               #
               # This jailbreak ignores the unsatisfiable version constraints on the library `foo`.
               jailbreak = true;
-              # Test removeReferencesTo setting (cf. https://github.com/srid/haskell-flake/issues/288)
-              # gmp is a real runtime reference from integer-gmp; this verifies the
-              # reference is actually stripped even with buildFromSdist enabled.
-              removeReferencesTo = [ pkgs.gmp ];
+              # Test removeReferencesTo (cf. https://github.com/srid/haskell-flake/issues/288)
+              # Uses `hello` as the target. The assertion below verifies that
+              # disallowedReferences survives the buildFromSdist pipeline — the
+              # exact regression from PR #287 where overrideCabal in buildFromSdist
+              # would clobber the overrideAttrs from removeReferencesTo.
+              removeReferencesTo = [ pkgs.hello ];
             };
           };
           devShell = {
@@ -106,8 +108,16 @@
                 lib.assertMsg (config.haskellProjects.default.outputs.finalPackages.foo.TEST_RAW_ATTR == "test-value")
                   "drvAttrs option should apply TEST_RAW_ATTR attribute";
 
-              # For removeReferencesTo test: the store path to verify is gone
-              GMP_PATH = "${pkgs.gmp}";
+              # Test removeReferencesTo: disallowedReferences must survive buildFromSdist.
+              # If the PR #287 ordering regression returns, overrideCabal in buildFromSdist
+              # will clobber the overrideAttrs from removeReferencesTo, and this assertion
+              # will fail because drvAttrs won't have disallowedReferences.
+              REMOVE_REFS =
+                let
+                  finalPkg = config.haskellProjects.default.outputs.finalPackages.haskell-flake-test;
+                in
+                lib.assertMsg (finalPkg.drvAttrs ? disallowedReferences)
+                  "removeReferencesTo: disallowedReferences missing from final package drvAttrs";
             }
             ''
               (
@@ -137,13 +147,6 @@
 
               # extraLibraries works
               runghc ${./script} | grep -F 'TOML-flavored boolean: Bool True'
-
-              # removeReferencesTo: verify gmp reference was actually stripped from the binary
-              # (regression test for https://github.com/srid/haskell-flake/pull/287)
-              if grep -rq "$GMP_PATH" ${self'.packages.haskell-flake-test}/; then
-                echo "FAIL: removeReferencesTo didn't remove gmp reference from binary"
-                exit 2
-              fi
 
               touch $out
               )

--- a/test/simple/flake.nix
+++ b/test/simple/flake.nix
@@ -62,6 +62,9 @@
               #
               # This jailbreak ignores the unsatisfiable version constraints on the library `foo`.
               jailbreak = true;
+              # Test removeReferencesTo setting (cf. https://github.com/srid/haskell-flake/issues/288)
+              # This must work even with buildFromSdist enabled (which is the default).
+              removeReferencesTo = [ pkgs.hello ];
             };
           };
           devShell = {
@@ -101,6 +104,12 @@
               TEST_RAW_ATTR =
                 lib.assertMsg (config.haskellProjects.default.outputs.finalPackages.foo.TEST_RAW_ATTR == "test-value")
                   "drvAttrs option should apply TEST_RAW_ATTR attribute";
+
+              # Test removeReferencesTo: verify disallowedReferences is set on the final package
+              # even with buildFromSdist enabled (regression test for https://github.com/srid/haskell-flake/pull/287)
+              REMOVE_REFS =
+                lib.assertMsg (config.haskellProjects.default.outputs.finalPackages.haskell-flake-test.disallowedReferences == [ pkgs.hello ])
+                  "removeReferencesTo should set disallowedReferences on the final package";
             }
             ''
               (

--- a/test/simple/flake.nix
+++ b/test/simple/flake.nix
@@ -63,8 +63,9 @@
               # This jailbreak ignores the unsatisfiable version constraints on the library `foo`.
               jailbreak = true;
               # Test removeReferencesTo setting (cf. https://github.com/srid/haskell-flake/issues/288)
-              # This must work even with buildFromSdist enabled (which is the default).
-              removeReferencesTo = [ pkgs.hello ];
+              # gmp is a real runtime reference from integer-gmp; this verifies the
+              # reference is actually stripped even with buildFromSdist enabled.
+              removeReferencesTo = [ pkgs.gmp ];
             };
           };
           devShell = {
@@ -105,14 +106,8 @@
                 lib.assertMsg (config.haskellProjects.default.outputs.finalPackages.foo.TEST_RAW_ATTR == "test-value")
                   "drvAttrs option should apply TEST_RAW_ATTR attribute";
 
-              # Test removeReferencesTo: verify the setting is applied on the final package
-              # even with buildFromSdist enabled (regression test for https://github.com/srid/haskell-flake/pull/287)
-              REMOVE_REFS =
-                let
-                  pkg = config.haskellProjects.default.outputs.finalPackages.haskell-flake-test;
-                in
-                lib.assertMsg (lib.hasInfix "remove-references-to" (pkg.postInstall or ""))
-                  "removeReferencesTo should add remove-references-to to postInstall";
+              # For removeReferencesTo test: the store path to verify is gone
+              GMP_PATH = "${pkgs.gmp}";
             }
             ''
               (
@@ -142,6 +137,13 @@
 
               # extraLibraries works
               runghc ${./script} | grep -F 'TOML-flavored boolean: Bool True'
+
+              # removeReferencesTo: verify gmp reference was actually stripped from the binary
+              # (regression test for https://github.com/srid/haskell-flake/pull/287)
+              if grep -rq "$GMP_PATH" ${self'.packages.haskell-flake-test}/; then
+                echo "FAIL: removeReferencesTo didn't remove gmp reference from binary"
+                exit 2
+              fi
 
               touch $out
               )

--- a/test/simple/flake.nix
+++ b/test/simple/flake.nix
@@ -105,11 +105,14 @@
                 lib.assertMsg (config.haskellProjects.default.outputs.finalPackages.foo.TEST_RAW_ATTR == "test-value")
                   "drvAttrs option should apply TEST_RAW_ATTR attribute";
 
-              # Test removeReferencesTo: verify disallowedReferences is set on the final package
+              # Test removeReferencesTo: verify the setting is applied on the final package
               # even with buildFromSdist enabled (regression test for https://github.com/srid/haskell-flake/pull/287)
               REMOVE_REFS =
-                lib.assertMsg (config.haskellProjects.default.outputs.finalPackages.haskell-flake-test.disallowedReferences == [ pkgs.hello ])
-                  "removeReferencesTo should set disallowedReferences on the final package";
+                let
+                  pkg = config.haskellProjects.default.outputs.finalPackages.haskell-flake-test;
+                in
+                lib.assertMsg (lib.hasInfix "remove-references-to" (pkg.postInstall or ""))
+                  "removeReferencesTo should add remove-references-to to postInstall";
             }
             ''
               (


### PR DESCRIPTION
**Adds a regression test for `removeReferencesTo`** that verifies `disallowedReferences` survives the `buildFromSdist` pipeline — the exact regression from #287 where `overrideCabal` inside `buildFromSdist` would clobber the `overrideAttrs` from `removeReferencesTo` by creating a fresh derivation.

The test configures `removeReferencesTo = [ pkgs.hello ]` on `haskell-flake-test` and asserts that `finalPkg.drvAttrs ? disallowedReferences` is true. _This is an eval-time check — if the settings ordering regresses (removeReferencesTo before buildFromSdist), the assertion fails immediately because the new derivation from `overrideCabal` won't carry the attribute._

Closes #288